### PR TITLE
Add support for nodejs v12/v14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,15 @@ name: test
 on: pull_request
 jobs:
   test:
+    strategy:
+      matrix:
+        node: [12.x, 14.x, 16.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: ${{ matrix.node }}
       - run: |
           npm install --silent
           npm run lint


### PR DESCRIPTION
Currently, the tests for this library are only running on nodejs v16.