### PR TITLE
Add eslint matrix on ci (with continue-on-error)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,15 @@ jobs:
     strategy:
       matrix:
         node: [12.x, 14.x, 16.x]
+        eslint: [7, 8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+      - name: Use ESLint ${{ matrix.eslint }}
+        run: npm install eslint@${{ matrix.eslint }}
       - run: |
           npm install --silent
           npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,9 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Use ESLint ${{ matrix.eslint }}
         run: npm install eslint@${{ matrix.eslint }}
+        continue-on-error: ${{ matrix.eslint == '8' }}
       - run: |
           npm install --silent
           npm run lint
           npm run test
+        continue-on-error: ${{ matrix.eslint == '8' }}


### PR DESCRIPTION
## Why

This is a first step for supporting eslint v8.

## What
Run both eslint v7 and v8 on ci.
Ignore eslint v8 errors.

refs #14