### PR TITLE
Be available with both eslint 7 and eslint 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Use ESLint ${{ matrix.eslint }}
         run: npm install eslint@${{ matrix.eslint }}
-        continue-on-error: ${{ matrix.eslint == '8' }}
       - run: |
           npm install --silent
           npm run lint
           npm run test
-        continue-on-error: ${{ matrix.eslint == '8' }}

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   },
   "homepage": "https://github.com/moneyforward/eslint-config-moneyforward#readme",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.28.0",
-    "@typescript-eslint/parser": "^4.28.0",
+    "@typescript-eslint/eslint-plugin": "^4.28.0 || ^5.0.0",
+    "@typescript-eslint/parser": "^4.28.0 || ^5.0.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-jest": "^24.3.6",
+    "eslint-plugin-jest": "^24.3.6 || ^25.0.0",
     "eslint-plugin-jest-dom": "^3.9.0",
     "eslint-plugin-next": "^0.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-testing-library": "^4.6.0"
+    "eslint-plugin-testing-library": "^4.6.0 || ^5.0.0"
   },
   "devDependencies": {
     "eslint": "^7.29.0",


### PR DESCRIPTION
## Why
Be available with eslint 8

## What
- relax dependencies for eslint 8
- detect error on eslint 8

fixes #14

## Other

for local confirmation:
```
rm package-lock.json
rm -rf ./node_modules
npm install eslint@^8.0.0
or
npm install eslint@^7.29.0
```