### PR TITLE
add support for Node.js v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [12.x, 14.x, 16.x]
+        node: [12.x, 14.x, 16.x, 18.x]
         eslint: [7, 8]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Node.js v18 is now "Current" release status.
https://github.com/nodejs/release#release-schedule

So I add support for Node.js v18.