### PR TITLE
EOS for Node.js v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [12.x, 14.x, 16.x, 18.x]
+        node: [14.x, 16.x, 18.x]
         eslint: [7, 8]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Background of PR

Node.js v12 was EOS from Jest v29

https://jestjs.io/docs/upgrading-to-jest29

We should merge also this PR.

https://github.com/moneyforward/eslint-config-moneyforward/pull/69

# Changes

- remove node v12 test