### PR TITLE
ci: Check Pull Request Title

### DIFF
--- a/.github/workflows/check_pull_request_title.yml
+++ b/.github/workflows/check_pull_request_title.yml
@@ -1,0 +1,37 @@
+name: Check Pull Request Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Based on the Angular convention
+          # cf. https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
## Summary

Introduce a GitHub Action called [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to check that the Pull Request title is in the appropriate format.

## References

- [frontend-forward/docs/ADRs/2024-02-05-force-pull-request-title-format-for-oss.md at main · moneyforward/frontend-forward](https://github.com/moneyforward/frontend-forward/blob/main/docs/ADRs/2024-02-05-force-pull-request-title-format-for-oss.md)
- https://github.com/moneyforward/frontend-forward/issues/72
