### PR TITLE
feat: Implement the rule "errors"

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2012 Airbnb
+ *
+ * Licensed under the MIT License: https://github.com/airbnb/javascript/blob/master/LICENSE.md
+ *
+ * This file is a copy of https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/errors.js
+ * with the following modification:
+ *
+ * - Add `info`, `warn`, `error`, `time` and `timeEnd` to the allow list of `no-console`
+ */
+
 module.exports = {
   rules: {
     // Enforce “for” loop update clause moving the counter in the right direction

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -1,0 +1,197 @@
+module.exports = {
+  rules: {
+    // Enforce “for” loop update clause moving the counter in the right direction
+    // https://eslint.org/docs/rules/for-direction
+    'for-direction': ['error'],
+
+    // Enforces that a return statement is present in property getters
+    // https://eslint.org/docs/rules/getter-return
+    'getter-return': ['error', { allowImplicit: true }],
+
+    // disallow using an async function as a Promise executor
+    // https://eslint.org/docs/rules/no-async-promise-executor
+    'no-async-promise-executor': ['error'],
+
+    // Disallow await inside of loops
+    // https://eslint.org/docs/rules/no-await-in-loop
+    'no-await-in-loop': ['error'],
+
+    // Disallow comparisons to negative zero
+    // https://eslint.org/docs/rules/no-compare-neg-zero
+    'no-compare-neg-zero': ['error'],
+
+    // disallow assignment in conditional expressions
+    // https://eslint.org/docs/latest/rules/no-cond-assign
+    'no-cond-assign': ['error', 'always'],
+
+    // disallow use of console
+    // https://eslint.org/docs/latest/rules/no-console
+    'no-console': [
+      'warn',
+      {
+        allow: ['info', 'warn', 'error', 'time', 'timeEnd'],
+      },
+    ],
+
+    // Disallows expressions where the operation doesn't affect the value
+    // https://eslint.org/docs/rules/no-constant-binary-expression
+    'no-constant-binary-expression': ['error'],
+
+    // disallow use of constant expressions in conditions
+    'no-constant-condition': ['error'],
+
+    // disallow control characters in regular expressions
+    'no-control-regex': ['error'],
+
+    // disallow use of debugger
+    'no-debugger': ['error'],
+
+    // disallow duplicate arguments in functions
+    'no-dupe-args': ['error'],
+
+    // Disallow duplicate conditions in if-else-if chains
+    // https://eslint.org/docs/rules/no-dupe-else-if
+    'no-dupe-else-if': ['error'],
+
+    // disallow duplicate keys when creating object literals
+    'no-dupe-keys': ['error'],
+
+    // disallow a duplicate case label.
+    'no-duplicate-case': ['error'],
+
+    // disallow empty statements
+    'no-empty': ['error'],
+
+    // disallow the use of empty character classes in regular expressions
+    // https://eslint.org/docs/latest/rules/no-empty-character-class
+    'no-empty-character-class': ['error'],
+
+    // disallow assigning to the exception in a catch block
+    'no-ex-assign': ['error'],
+
+    // disallow double-negation boolean casts in a boolean context
+    // https://eslint.org/docs/rules/no-extra-boolean-cast
+    'no-extra-boolean-cast': ['error'],
+
+    // disallow unnecessary parentheses
+    // https://eslint.org/docs/rules/no-extra-parens
+    'no-extra-parens': [
+      'off',
+      'all',
+      {
+        conditionalAssign: true,
+        nestedBinaryExpressions: false,
+        returnAssign: false,
+        ignoreJSX: 'all', // delegate to eslint-plugin-react
+        enforceForArrowConditionals: false,
+      },
+    ],
+
+    // disallow unnecessary semicolons
+    'no-extra-semi': ['error'],
+
+    // disallow overwriting functions written as function declarations
+    'no-func-assign': ['error'],
+
+    // https://eslint.org/docs/rules/no-import-assign
+    'no-import-assign': ['error'],
+
+    // disallow function or variable declarations in nested blocks
+    'no-inner-declarations': ['error'],
+
+    // disallow invalid regular expression strings in the RegExp constructor
+    'no-invalid-regexp': ['error'],
+
+    // disallow irregular whitespace outside of strings and comments
+    'no-irregular-whitespace': ['error'],
+
+    // Disallow Number Literals That Lose Precision
+    // https://eslint.org/docs/rules/no-loss-of-precision
+    'no-loss-of-precision': ['error'],
+
+    // Disallow characters which are made with multiple code points in character class syntax
+    // https://eslint.org/docs/rules/no-misleading-character-class
+    'no-misleading-character-class': ['error'],
+
+    // disallow the use of object properties of the global object (Math and JSON) as functions
+    'no-obj-calls': ['error'],
+
+    // Disallow new operators with global non-constructor functions
+    // https://eslint.org/docs/latest/rules/no-new-native-nonconstructor
+    'no-new-native-nonconstructor': ['error'],
+
+    // Disallow returning values from Promise executor functions
+    // https://eslint.org/docs/rules/no-promise-executor-return
+    'no-promise-executor-return': ['error'],
+
+    // disallow use of Object.prototypes builtins directly
+    // https://eslint.org/docs/rules/no-prototype-builtins
+    'no-prototype-builtins': ['error'],
+
+    // disallow multiple spaces in a regular expression literal
+    'no-regex-spaces': ['error'],
+
+    // Disallow returning values from setters
+    // https://eslint.org/docs/rules/no-setter-return
+    'no-setter-return': ['error'],
+
+    // disallow sparse arrays
+    'no-sparse-arrays': ['error'],
+
+    // Disallow template literal placeholder syntax in regular strings
+    // https://eslint.org/docs/rules/no-template-curly-in-string
+    'no-template-curly-in-string': ['error'],
+
+    // Avoid code that looks like two expressions but is actually one
+    // https://eslint.org/docs/rules/no-unexpected-multiline
+    'no-unexpected-multiline': ['error'],
+
+    // disallow unreachable statements after a return, throw, continue, or break statement
+    'no-unreachable': ['error'],
+
+    // Disallow loops with a body that allows only one iteration
+    // https://eslint.org/docs/rules/no-unreachable-loop
+    'no-unreachable-loop': [
+      'error',
+      {
+        ignore: [], // WhileStatement, DoWhileStatement, ForStatement, ForInStatement, ForOfStatement
+      },
+    ],
+
+    // disallow return/throw/break/continue inside finally blocks
+    // https://eslint.org/docs/rules/no-unsafe-finally
+    'no-unsafe-finally': 'error',
+
+    // disallow negating the left operand of relational operators
+    // https://eslint.org/docs/rules/no-unsafe-negation
+    'no-unsafe-negation': 'error',
+
+    // disallow use of optional chaining in contexts where the undefined value is not allowed
+    // https://eslint.org/docs/rules/no-unsafe-optional-chaining
+    'no-unsafe-optional-chaining': [
+      'error',
+      { disallowArithmeticOperators: true },
+    ],
+
+    // Disallow Unused Private Class Members
+    // https://eslint.org/docs/rules/no-unused-private-class-members
+    // TODO: enable once eslint 7 is dropped (which is semver-major)
+    'no-unused-private-class-members': ['off'],
+
+    // Disallow useless backreferences in regular expressions
+    // https://eslint.org/docs/rules/no-useless-backreference
+    'no-useless-backreference': ['error'],
+
+    // Disallow assignments that can lead to race conditions due to usage of await or yield
+    // https://eslint.org/docs/rules/require-atomic-updates
+    // note: not enabled because it is very buggy
+    'require-atomic-updates': ['off'],
+
+    // disallow comparisons with the value NaN
+    'use-isnan': ['error'],
+
+    // ensure that the results of typeof are compared against a valid string
+    // https://eslint.org/docs/rules/valid-typeof
+    'valid-typeof': ['error', { requireStringLiterals: true }],
+  },
+};


### PR DESCRIPTION
## Summary

Implement the ruleset by referring to the [errors](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/errors.js) of [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base).

However, the following rule is set by us:

- [no-console](https://eslint.org/docs/latest/rules/no-console)
  -  `info`, `warn`, `error`, `time`, and `timeEnd` are permitted because they are useful.

## References

- [javascript/packages/eslint-config-airbnb-base/rules/errors.js at master · airbnb/javascript](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/errors.js)
- [Rules Reference - ESLint - Pluggable JavaScript Linter](https://eslint.org/docs/latest/rules/)
- #184 