### PR TITLE
feat: Implement the rule "imports"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
         "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-jest-dom": "^4.0.3",
         "eslint-plugin-n": "^16.6.2",
@@ -1662,6 +1663,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
     "node_modules/@types/node": {
       "version": "20.11.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
@@ -2181,6 +2187,42 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.filter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
+      "integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz",
+      "integrity": "sha512-hzvSHUshSpCflDR1QMUBLHGHP1VIEBegT4pix9H/Z92Xw3ySoy6c2qh7lJWTJnRJ8JCZ9bJNCgTyYaJGcJu6xQ==",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -3676,8 +3718,7 @@
     "node_modules/es-array-method-boxes-properly": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -3969,6 +4010,48 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
+      "integrity": "sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/eslint-plugin-es-x": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
@@ -3986,6 +4069,55 @@
       },
       "peerDependencies": {
         "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
+      "dependencies": {
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.8.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint-plugin-jest": {
@@ -7028,7 +7160,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7258,6 +7389,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.2.tgz",
+      "integrity": "sha512-bzBq58S+x+uo0VjurFT0UktpKHOZmv4/xePiOA1nbB9pMqpGK7rUPNgf+1YC+7mE+0HzhTMqNUuCqvKhj6FnBw==",
+      "dependencies": {
+        "array.prototype.filter": "^1.0.3",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.0.0"
       }
     },
     "node_modules/object.hasown": {
@@ -9081,6 +9224,36 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/tslib": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-n": "^16.6.2",

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -213,7 +213,7 @@ module.exports = {
     // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/group-exports.md
     'import/group-exports': ['off'],
 
-    // forbid default exports. this is a terrible rule, do not use it.
+    // forbid default exports.
     // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
     'import/no-default-export': ['error'],
 

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -6,7 +6,7 @@
  * This file is a copy of https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js
  * with the following modifications:
  *
- * - Disable `import/extensions` rule to force import path to include file extension
+ * - Disable `import/extensions` rule to avoid including file extensions in the import path
  * - Disable `import/prefer-default-export` rule to allow named exports
  * - Enable `import/no-default-export` rule to disallow default exports
  */

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -106,7 +106,6 @@ module.exports = {
 
     // No Node.js builtin modules
     // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md
-    // TODO: enable?
     'import/no-nodejs-modules': ['off'],
 
     /*
@@ -116,12 +115,6 @@ module.exports = {
     // disallow non-import statements appearing before import statements
     // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md
     'import/first': ['error'],
-
-    // disallow non-import statements appearing before import statements
-    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/imports-first.md
-    // deprecated: use `import/first`
-    // TODO: Remove this rule.
-    'import/imports-first': ['off'],
 
     // disallow duplicate imports
     // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2012 Airbnb
+ *
+ * Licensed under the MIT License: https://github.com/airbnb/javascript/blob/master/LICENSE.md
+ *
+ * This file is a copy of https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js
+ * with the following modifications:
+ *
+ * - Disable `import/extensions` rule to force import path to include file extension
+ * - Disable `import/prefer-default-export` rule to allow named exports
+ * - Enable `import/no-default-export` rule to disallow default exports
+ */
+
+module.exports = {
+  plugins: ['import'],
+  extends: ['plugin:import/recommended', 'plugin:import/errors'],
+
+  rules: {
+    /*
+     * Static analysis:
+     */
+
+    // ensure imports point to files/modules that can be resolved
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md
+    // Disable it if you want to be able to refer to workspace packages with absolute paths.
+    'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
+
+    // ensure named imports coupled with named exports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md#when-not-to-use-it
+    'import/named': ['error'],
+
+    // ensure default import coupled with default export
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md#when-not-to-use-it
+    'import/default': ['off'],
+
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md
+    'import/namespace': ['off'],
+
+    /*
+     * Helpful warnings:
+     */
+
+    // disallow invalid exports, e.g. multiple defaults
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/export.md
+    'import/export': ['error'],
+
+    // do not allow a default import name to match a named export
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default.md
+    'import/no-named-as-default': ['error'],
+
+    // warn on accessing default export property names that are also named exports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md
+    'import/no-named-as-default-member': ['error'],
+
+    // disallow use of jsdoc-marked-deprecated imports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-deprecated.md
+    'import/no-deprecated': ['off'],
+
+    // Forbid the use of extraneous packages
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md
+    // paths are treated both as absolute paths, and relative to process.cwd()
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: [
+          'test/**', // tape, common npm pattern
+          'tests/**', // also common npm pattern
+          'spec/**', // mocha, rspec-like pattern
+          '**/__tests__/**', // jest pattern
+          '**/__mocks__/**', // jest pattern
+          'test.{js,jsx}', // repos with a single test file
+          'test-*.{js,jsx}', // repos with multiple top-level test files
+          '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
+          '**/jest.config.js', // jest config
+          '**/jest.setup.js', // jest setup
+          '**/vue.config.js', // vue-cli config
+          '**/webpack.config.js', // webpack config
+          '**/webpack.config.*.js', // webpack config
+          '**/rollup.config.js', // rollup config
+          '**/rollup.config.*.js', // rollup config
+          '**/protractor.conf.js', // protractor config
+          '**/protractor.conf.*.js', // protractor config
+          '**/karma.conf.js', // karma config
+          '**/.eslintrc.js', // eslint config
+          '**/eslint-rules/**',
+        ],
+        optionalDependencies: false,
+      },
+    ],
+
+    // Forbid mutable exports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-mutable-exports.md
+    'import/no-mutable-exports': ['error'],
+
+    /*
+     * Module systems:
+     */
+
+    // disallow require()
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-commonjs.md
+    'import/no-commonjs': ['off'],
+
+    // disallow AMD require/define
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-amd.md
+    'import/no-amd': ['error'],
+
+    // No Node.js builtin modules
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md
+    // TODO: enable?
+    'import/no-nodejs-modules': ['off'],
+
+    /*
+     * Style guide:
+     */
+
+    // disallow non-import statements appearing before import statements
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md
+    'import/first': ['error'],
+
+    // disallow non-import statements appearing before import statements
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/imports-first.md
+    // deprecated: use `import/first`
+    // TODO: Remove this rule.
+    'import/imports-first': ['off'],
+
+    // disallow duplicate imports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md
+    'import/no-duplicates': ['error'],
+
+    // disallow namespace imports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-namespace.md
+    'import/no-namespace': ['off'],
+
+    // Ensure consistent use of file extension within the import path
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md
+    'import/extensions': ['off'],
+
+    // ensure absolute imports are above relative imports and that unassigned imports are ignored
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md
+    // TODO: enforce a stricter convention in module import order?
+    'import/order': [
+      'error',
+      { groups: [['builtin', 'external', 'internal']] },
+    ],
+
+    // Require a newline after the last import/require in a group
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md
+    'import/newline-after-import': ['error'],
+
+    // Require modules with a single export to use a default export
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md
+    'import/prefer-default-export': ['off'],
+
+    // Restrict which files can be imported in a given folder
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md
+    'import/no-restricted-paths': ['off'],
+
+    // Forbid modules to have too many dependencies
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/max-dependencies.md
+    'import/max-dependencies': ['off', { max: 10 }],
+
+    // Forbid import of modules using absolute paths
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-absolute-path.md
+    'import/no-absolute-path': ['error'],
+
+    // Forbid require() calls with expressions
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-dynamic-require.md
+    'import/no-dynamic-require': ['error'],
+
+    // prevent importing the submodules of other modules
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-internal-modules.md
+    'import/no-internal-modules': [
+      'off',
+      {
+        allow: [],
+      },
+    ],
+
+    // Warn if a module could be mistakenly parsed as a script by a consumer
+    // leveraging Unambiguous JavaScript Grammar
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/unambiguous.md
+    // this should not be enabled until this proposal has at least been *presented* to TC39.
+    // At the moment, it's not a thing.
+    'import/unambiguous': ['off'],
+
+    // Forbid Webpack loader syntax in imports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-webpack-loader-syntax.md
+    'import/no-webpack-loader-syntax': ['error'],
+
+    // Prevent unassigned imports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unassigned-import.md
+    // importing for side effects is perfectly acceptable, if you need side effects.
+    'import/no-unassigned-import': ['off'],
+
+    // Prevent importing the default as if it were named
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-default.md
+    'import/no-named-default': ['error'],
+
+    // Reports if a module's default export is unnamed
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-anonymous-default-export.md
+    'import/no-anonymous-default-export': [
+      'off',
+      {
+        allowArray: false,
+        allowArrowFunction: false,
+        allowAnonymousClass: false,
+        allowAnonymousFunction: false,
+        allowLiteral: false,
+        allowObject: false,
+      },
+    ],
+
+    // This rule enforces that all exports are declared at the bottom of the file.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/exports-last.md
+    'import/exports-last': ['off'],
+
+    // Reports when named exports are not grouped together in a single export declaration
+    // or when multiple assignments to CommonJS module.exports or exports object are present
+    // in a single file.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/group-exports.md
+    'import/group-exports': ['off'],
+
+    // forbid default exports. this is a terrible rule, do not use it.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
+    'import/no-default-export': ['error'],
+
+    // Prohibit named exports. this is a terrible rule, do not use it.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-export.md
+    'import/no-named-export': ['off'],
+
+    // Forbid a module from importing itself
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md
+    'import/no-self-import': ['error'],
+
+    // Forbid cyclical dependencies between modules
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md
+    'import/no-cycle': ['error', { maxDepth: '∞' }],
+
+    // Ensures that there are no useless path segments
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-useless-path-segments.md
+    'import/no-useless-path-segments': ['error', { commonjs: true }],
+
+    // dynamic imports require a leading comment with a webpackChunkName
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/dynamic-import-chunkname.md
+    'import/dynamic-import-chunkname': [
+      'off',
+      {
+        importFunctions: [],
+        webpackChunknameFormat: '[0-9a-zA-Z-_/.]+',
+      },
+    ],
+
+    // Use this rule to prevent imports to folders in relative parent paths.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-parent-imports.md
+    'import/no-relative-parent-imports': ['off'],
+
+    // Reports modules without any exports, or with unused exports
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unused-modules.md
+    // TODO: enable once it supports CJS
+    'import/no-unused-modules': [
+      'off',
+      {
+        ignoreExports: [],
+        missingExports: true,
+        unusedExports: true,
+      },
+    ],
+
+    // Reports the use of import declarations with CommonJS exports in any module except for the main module.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-import-module-exports.md
+    'import/no-import-module-exports': [
+      'error',
+      {
+        exceptions: [],
+      },
+    ],
+
+    // Use this rule to prevent importing packages through relative paths.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-relative-packages.md
+    'import/no-relative-packages': ['error'],
+
+    // enforce a consistent style for type specifiers (inline or top-level)
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/consistent-type-specifier-style.md
+    'import/consistent-type-specifier-style': ['error', 'prefer-inline'],
+
+    // Reports the use of empty named import blocks.
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-empty-named-blocks.md
+    'import/no-empty-named-blocks': ['error'],
+  },
+};


### PR DESCRIPTION
## Summary

Implement the ruleset by referring to the [imports](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js) of [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base).

However, the following rules are set by us:

- [import/extensions](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md)
  - Disable it to avoid including file extensions in the import path.
- [import/prefer-default-export](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md)
  - Disable it to allow named exports.
- [import/no-default-export](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md)
  - Enable it to disallow default exports.

## References

- [javascript/packages/eslint-config-airbnb-base/rules/imports.js at master · airbnb/javascript](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js)
- [eslint-plugin-import - npm](https://www.npmjs.com/package/eslint-plugin-import)
- #186 
