### PR TITLE
chore: disable option `requireReturnForObjectLiteral` in `arrow-body-style`

### DIFF
--- a/rules/es6.js
+++ b/rules/es6.js
@@ -6,7 +6,6 @@
  * This file is a copy of https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/es6.js
  * with the following modifications:
  *
- * - Turn `requireReturnForObjectLiteral` to `true` in `arrow-body-style`
  * - Turn off `no-useless-constructor` because it's unnecessary with TypeScript
  */
 
@@ -18,7 +17,7 @@ module.exports = {
       'error',
       'as-needed',
       {
-        requireReturnForObjectLiteral: true,
+        requireReturnForObjectLiteral: false,
       },
     ],
 


### PR DESCRIPTION
## Summary

This PR is a patch for fix #212.

Disable `requireReturnForObjectLiteral` in `arrow-body-style` rule. This is because if this option is enabled, `return` cannot be omitted.

```js
/*
 * eslint arrow-body-style: ["error", "as-needed", {
 *   "requireReturnForObjectLiteral": true
 * }]
 */

const foo = () => ({ foo: 0 });           // 💥Invalid
const bar = () => { return { bar: 0 }; }; // 👍Valid
```

**TO-BE**

```js
/*
 * eslint arrow-body-style: ["error", "as-needed", {
 *   "requireReturnForObjectLiteral": false
 * }]
 */

const foo = () => ({ foo: 0 });           // 👍Valid
const bar = () => { return { bar: 0 }; }; // 💥Invalid
```

## References

- #212
- [arrow-body-style - ESLint - Pluggable JavaScript Linter](https://eslint.org/docs/latest/rules/arrow-body-style#requirereturnforobjectliteral)