### PR TITLE
feat: Implement the rule "style"

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -1,0 +1,644 @@
+module.exports = {
+  rules: {
+    // enforce line breaks after opening and before closing array brackets
+    // https://eslint.org/docs/rules/array-bracket-newline
+    // TODO: enable? semver-major
+    'array-bracket-newline': ['off', 'consistent'], // object option alternative: { multiline: true, minItems: 3 }
+
+    // enforce line breaks between array elements
+    // https://eslint.org/docs/rules/array-element-newline
+    // TODO: enable? semver-major
+    'array-element-newline': ['off', { multiline: true, minItems: 3 }],
+
+    // enforce spacing inside array brackets
+    'array-bracket-spacing': ['error', 'never'],
+
+    // enforce spacing inside single-line blocks
+    // https://eslint.org/docs/rules/block-spacing
+    'block-spacing': ['error', 'always'],
+
+    // enforce one true brace style
+    'brace-style': ['error', '1tbs', { allowSingleLine: true }],
+
+    // require camel case names
+    camelcase: ['error', { properties: 'never', ignoreDestructuring: false }],
+
+    // enforce or disallow capitalization of the first letter of a comment
+    // https://eslint.org/docs/rules/capitalized-comments
+    'capitalized-comments': [
+      'off',
+      'never',
+      {
+        line: {
+          ignorePattern: '.*',
+          ignoreInlineComments: true,
+          ignoreConsecutiveComments: true,
+        },
+        block: {
+          ignorePattern: '.*',
+          ignoreInlineComments: true,
+          ignoreConsecutiveComments: true,
+        },
+      },
+    ],
+
+    // require trailing commas in multiline object literals
+    'comma-dangle': [
+      'error',
+      {
+        arrays: 'always-multiline',
+        objects: 'always-multiline',
+        imports: 'always-multiline',
+        exports: 'always-multiline',
+        functions: 'always-multiline',
+      },
+    ],
+
+    // enforce spacing before and after comma
+    'comma-spacing': ['error', { before: false, after: true }],
+
+    // enforce one true comma style
+    'comma-style': [
+      'error',
+      'last',
+      {
+        exceptions: {
+          ArrayExpression: false,
+          ArrayPattern: false,
+          ArrowFunctionExpression: false,
+          CallExpression: false,
+          FunctionDeclaration: false,
+          FunctionExpression: false,
+          ImportDeclaration: false,
+          ObjectExpression: false,
+          ObjectPattern: false,
+          VariableDeclaration: false,
+          NewExpression: false,
+        },
+      },
+    ],
+
+    // disallow padding inside computed properties
+    'computed-property-spacing': ['error', 'never'],
+
+    // enforces consistent naming when capturing the current execution context
+    'consistent-this': 'off',
+
+    // enforce newline at the end of file, with no multiple empty lines
+    'eol-last': ['error', 'always'],
+
+    // https://eslint.org/docs/rules/function-call-argument-newline
+    'function-call-argument-newline': ['error', 'consistent'],
+
+    // enforce spacing between functions and their invocations
+    // https://eslint.org/docs/rules/func-call-spacing
+    'func-call-spacing': ['error', 'never'],
+
+    // requires function names to match the name of the variable or property to which they are
+    // assigned
+    // https://eslint.org/docs/rules/func-name-matching
+    'func-name-matching': [
+      'off',
+      'always',
+      {
+        includeCommonJSModuleExports: false,
+        considerPropertyDescriptor: true,
+      },
+    ],
+
+    // require function expressions to have a name
+    // https://eslint.org/docs/rules/func-names
+    'func-names': ['error'],
+
+    // enforces use of function declarations or expressions
+    // https://eslint.org/docs/rules/func-style
+    // TODO: enable
+    'func-style': ['off', 'expression'],
+
+    // require line breaks inside function parentheses if there are line breaks between parameters
+    // https://eslint.org/docs/rules/function-paren-newline
+    'function-paren-newline': ['error', 'multiline-arguments'],
+
+    // disallow specified identifiers
+    // https://eslint.org/docs/rules/id-denylist
+    'id-denylist': 'off',
+
+    // this option enforces minimum and maximum identifier lengths
+    // (variable names, property names etc.)
+    'id-length': 'off',
+
+    // require identifiers to match the provided regular expression
+    'id-match': 'off',
+
+    // Enforce the location of arrow function bodies with implicit returns
+    // https://eslint.org/docs/rules/implicit-arrow-linebreak
+    'implicit-arrow-linebreak': ['error', 'beside'],
+
+    // this option sets a specific tab width for your code
+    // https://eslint.org/docs/rules/indent
+    indent: [
+      'error',
+      2,
+      {
+        SwitchCase: 1,
+        VariableDeclarator: 1,
+        outerIIFEBody: 1,
+        // MemberExpression: null,
+        FunctionDeclaration: {
+          parameters: 1,
+          body: 1,
+        },
+        FunctionExpression: {
+          parameters: 1,
+          body: 1,
+        },
+        CallExpression: {
+          arguments: 1,
+        },
+        ArrayExpression: 1,
+        ObjectExpression: 1,
+        ImportDeclaration: 1,
+        flatTernaryExpressions: false,
+        // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
+        ignoredNodes: [
+          'JSXElement',
+          'JSXElement > *',
+          'JSXAttribute',
+          'JSXIdentifier',
+          'JSXNamespacedName',
+          'JSXMemberExpression',
+          'JSXSpreadAttribute',
+          'JSXExpressionContainer',
+          'JSXOpeningElement',
+          'JSXClosingElement',
+          'JSXFragment',
+          'JSXOpeningFragment',
+          'JSXClosingFragment',
+          'JSXText',
+          'JSXEmptyExpression',
+          'JSXSpreadChild',
+        ],
+        ignoreComments: false,
+      },
+    ],
+
+    // specify whether double or single quotes should be used in JSX attributes
+    // https://eslint.org/docs/rules/jsx-quotes
+    'jsx-quotes': ['off', 'prefer-double'],
+
+    // enforces spacing between keys and values in object literal properties
+    'key-spacing': ['error', { beforeColon: false, afterColon: true }],
+
+    // require a space before & after certain keywords
+    'keyword-spacing': [
+      'error',
+      {
+        before: true,
+        after: true,
+        overrides: {
+          return: { after: true },
+          throw: { after: true },
+          case: { after: true },
+        },
+      },
+    ],
+
+    // enforce position of line comments
+    // https://eslint.org/docs/rules/line-comment-position
+    // TODO: enable?
+    'line-comment-position': [
+      'off',
+      {
+        position: 'above',
+        ignorePattern: '',
+        applyDefaultPatterns: true,
+      },
+    ],
+
+    // disallow mixed 'LF' and 'CRLF' as linebreaks
+    // https://eslint.org/docs/rules/linebreak-style
+    'linebreak-style': ['error', 'unix'],
+
+    // require or disallow an empty line between class members
+    // https://eslint.org/docs/rules/lines-between-class-members
+    'lines-between-class-members': [
+      'error',
+      'always',
+      {
+        exceptAfterSingleLine: true,
+      },
+    ],
+
+    // enforces empty lines around comments
+    'lines-around-comment': 'off',
+
+    // require or disallow newlines around directives
+    // https://eslint.org/docs/rules/lines-around-directive
+    'lines-around-directive': [
+      'error',
+      {
+        before: 'always',
+        after: 'always',
+      },
+    ],
+
+    // specify the maximum depth that blocks can be nested
+    'max-depth': ['off', 4],
+
+    // specify the maximum length of a line in your program
+    // https://eslint.org/docs/rules/max-len
+    'max-len': [
+      'error',
+      100,
+      2,
+      {
+        ignoreUrls: true,
+        ignoreComments: false,
+        ignoreRegExpLiterals: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+      },
+    ],
+
+    // specify the max number of lines in a file
+    // https://eslint.org/docs/rules/max-lines
+    'max-lines': [
+      'off',
+      {
+        max: 300,
+        skipBlankLines: true,
+        skipComments: true,
+      },
+    ],
+
+    // enforce a maximum function length
+    // https://eslint.org/docs/rules/max-lines-per-function
+    'max-lines-per-function': [
+      'off',
+      {
+        max: 50,
+        skipBlankLines: true,
+        skipComments: true,
+        IIFEs: true,
+      },
+    ],
+
+    // specify the maximum depth callbacks can be nested
+    'max-nested-callbacks': 'off',
+
+    // limits the number of parameters that can be used in the function declaration.
+    'max-params': ['off', 3],
+
+    // specify the maximum number of statement allowed in a function
+    'max-statements': ['off', 10],
+
+    // restrict the number of statements per line
+    // https://eslint.org/docs/rules/max-statements-per-line
+    'max-statements-per-line': ['off', { max: 1 }],
+
+    // enforce a particular style for multiline comments
+    // https://eslint.org/docs/rules/multiline-comment-style
+    'multiline-comment-style': ['off', 'starred-block'],
+
+    // require multiline ternary
+    // https://eslint.org/docs/rules/multiline-ternary
+    // TODO: enable?
+    'multiline-ternary': ['off', 'never'],
+
+    // require a capital letter for constructors
+    'new-cap': [
+      'error',
+      {
+        newIsCap: true,
+        newIsCapExceptions: [],
+        capIsNew: false,
+        capIsNewExceptions: [
+          'Immutable.Map',
+          'Immutable.Set',
+          'Immutable.List',
+        ],
+      },
+    ],
+
+    // disallow the omission of parentheses when invoking a constructor with no arguments
+    // https://eslint.org/docs/rules/new-parens
+    'new-parens': 'error',
+
+    // allow/disallow an empty newline after var statement
+    'newline-after-var': 'off',
+
+    // https://eslint.org/docs/rules/newline-before-return
+    'newline-before-return': 'off',
+
+    // enforces new line after each method call in the chain to make it
+    // more readable and easy to maintain
+    // https://eslint.org/docs/rules/newline-per-chained-call
+    'newline-per-chained-call': ['error', { ignoreChainWithDepth: 4 }],
+
+    // disallow use of the Array constructor
+    'no-array-constructor': 'error',
+
+    // disallow use of bitwise operators
+    // https://eslint.org/docs/rules/no-bitwise
+    'no-bitwise': ['off'],
+
+    // disallow use of the continue statement
+    // https://eslint.org/docs/rules/no-continue
+    'no-continue': 'error',
+
+    // disallow comments inline after code
+    'no-inline-comments': 'off',
+
+    // disallow if as the only statement in an else block
+    // https://eslint.org/docs/rules/no-lonely-if
+    'no-lonely-if': 'error',
+
+    // disallow un-paren'd mixes of different operators
+    // https://eslint.org/docs/rules/no-mixed-operators
+    'no-mixed-operators': [
+      'error',
+      {
+        // the list of arithmetic groups disallows mixing `%` and `**`
+        // with other arithmetic operators.
+        groups: [
+          ['%', '**'],
+          ['%', '+'],
+          ['%', '-'],
+          ['%', '*'],
+          ['%', '/'],
+          ['/', '*'],
+          ['&', '|', '<<', '>>', '>>>'],
+          ['==', '!=', '===', '!=='],
+          ['&&', '||'],
+        ],
+        allowSamePrecedence: false,
+      },
+    ],
+
+    // disallow use of chained assignment expressions
+    // https://eslint.org/docs/rules/no-multi-assign
+    'no-multi-assign': ['error'],
+
+    // disallow multiple empty lines, only one newline at the end, and no new lines at the beginning
+    // https://eslint.org/docs/rules/no-multiple-empty-lines
+    'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
+
+    // disallow negated conditions
+    // https://eslint.org/docs/rules/no-negated-condition
+    'no-negated-condition': 'off',
+
+    // disallow nested ternary expressions
+    'no-nested-ternary': ['off'],
+
+    // disallow use of the Object constructor
+    'no-new-object': 'error',
+
+    // disallow use of unary operators, ++ and --
+    // https://eslint.org/docs/rules/no-plusplus
+    'no-plusplus': ['off'],
+
+    // disallow certain syntax forms
+    // https://eslint.org/docs/rules/no-restricted-syntax
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message:
+          'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+      },
+      {
+        selector: 'ForOfStatement',
+        message:
+          'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
+      },
+      {
+        selector: 'LabeledStatement',
+        message:
+          'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message:
+          '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+      {
+        selector: 'TSEnumDeclaration',
+        message: 'Do not declare enums',
+      },
+    ],
+
+    // disallow space between function identifier and application
+    'no-spaced-func': 'error',
+
+    // disallow tab characters entirely
+    'no-tabs': 'error',
+
+    // disallow the use of ternary operators
+    'no-ternary': 'off',
+
+    // disallow trailing whitespace at the end of lines
+    'no-trailing-spaces': [
+      'error',
+      {
+        skipBlankLines: false,
+        ignoreComments: false,
+      },
+    ],
+
+    // disallow dangling underscores in identifiers
+    // https://eslint.org/docs/rules/no-underscore-dangle
+    'no-underscore-dangle': [
+      'error',
+      {
+        allow: [],
+        allowAfterThis: false,
+        allowAfterSuper: false,
+        enforceInMethodNames: true,
+      },
+    ],
+
+    // disallow the use of Boolean literals in conditional expressions
+    // also, prefer `a || b` over `a ? a : b`
+    // https://eslint.org/docs/rules/no-unneeded-ternary
+    'no-unneeded-ternary': ['error', { defaultAssignment: false }],
+
+    // disallow whitespace before properties
+    // https://eslint.org/docs/rules/no-whitespace-before-property
+    'no-whitespace-before-property': 'error',
+
+    // enforce the location of single-line statements
+    // https://eslint.org/docs/rules/nonblock-statement-body-position
+    'nonblock-statement-body-position': ['error', 'beside', { overrides: {} }],
+
+    // require padding inside curly braces
+    'object-curly-spacing': ['error', 'always'],
+
+    // enforce line breaks between braces
+    // https://eslint.org/docs/rules/object-curly-newline
+    'object-curly-newline': [
+      'error',
+      {
+        ObjectExpression: {
+          minProperties: 4,
+          multiline: true,
+          consistent: true,
+        },
+        ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
+        ImportDeclaration: {
+          minProperties: 4,
+          multiline: true,
+          consistent: true,
+        },
+        ExportDeclaration: {
+          minProperties: 4,
+          multiline: true,
+          consistent: true,
+        },
+      },
+    ],
+
+    // enforce "same line" or "multiple line" on object properties.
+    // https://eslint.org/docs/rules/object-property-newline
+    'object-property-newline': [
+      'error',
+      {
+        allowAllPropertiesOnSameLine: true,
+      },
+    ],
+
+    // allow just one var statement per function
+    'one-var': ['error', 'never'],
+
+    // require a newline around variable declaration
+    // https://eslint.org/docs/rules/one-var-declaration-per-line
+    'one-var-declaration-per-line': ['error', 'always'],
+
+    // require assignment operator shorthand where possible or prohibit it entirely
+    // https://eslint.org/docs/rules/operator-assignment
+    'operator-assignment': ['error', 'always'],
+
+    // Requires operator at the beginning of the line in multiline statements
+    // https://eslint.org/docs/rules/operator-linebreak
+    'operator-linebreak': ['error', 'before', { overrides: { '=': 'none' } }],
+
+    // disallow padding within blocks
+    'padded-blocks': [
+      'error',
+      {
+        blocks: 'never',
+        classes: 'never',
+        switches: 'never',
+      },
+      {
+        allowSingleLineBlocks: true,
+      },
+    ],
+
+    // Require or disallow padding lines between statements
+    // https://eslint.org/docs/rules/padding-line-between-statements
+    'padding-line-between-statements': 'off',
+
+    // Disallow the use of Math.pow in favor of the ** operator
+    // https://eslint.org/docs/rules/prefer-exponentiation-operator
+    'prefer-exponentiation-operator': 'error',
+
+    // Prefer use of an object spread over Object.assign
+    // https://eslint.org/docs/rules/prefer-object-spread
+    'prefer-object-spread': 'error',
+
+    // require quotes around object literal property names
+    // https://eslint.org/docs/rules/quote-props.html
+    'quote-props': [
+      'error',
+      'as-needed',
+      { keywords: false, unnecessary: true, numbers: false },
+    ],
+
+    // specify whether double or single quotes should be used
+    quotes: ['error', 'single', { avoidEscape: true }],
+
+    // do not require jsdoc
+    // https://eslint.org/docs/rules/require-jsdoc
+    'require-jsdoc': 'off',
+
+    // require or disallow use of semicolons instead of ASI
+    semi: ['error', 'always'],
+
+    // enforce spacing before and after semicolons
+    'semi-spacing': ['error', { before: false, after: true }],
+
+    // Enforce location of semicolons
+    // https://eslint.org/docs/rules/semi-style
+    'semi-style': ['error', 'last'],
+
+    // requires object keys to be sorted
+    'sort-keys': ['off', 'asc', { caseSensitive: false, natural: true }],
+
+    // sort variables within the same declaration block
+    'sort-vars': 'off',
+
+    // require or disallow space before blocks
+    'space-before-blocks': 'error',
+
+    // require or disallow space before function opening parenthesis
+    // https://eslint.org/docs/rules/space-before-function-paren
+    'space-before-function-paren': [
+      'error',
+      {
+        anonymous: 'always',
+        named: 'never',
+        asyncArrow: 'always',
+      },
+    ],
+
+    // require or disallow spaces inside parentheses
+    'space-in-parens': ['error', 'never'],
+
+    // require spaces around operators
+    'space-infix-ops': 'error',
+
+    // Require or disallow spaces before/after unary operators
+    // https://eslint.org/docs/rules/space-unary-ops
+    'space-unary-ops': [
+      'error',
+      {
+        words: true,
+        nonwords: false,
+        overrides: {},
+      },
+    ],
+
+    // require or disallow a space immediately following the // or /* in a comment
+    // https://eslint.org/docs/rules/spaced-comment
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        line: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', '/'], // space here to support sprockets directives, slash for TS /// comments
+        },
+        block: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
+          balanced: true,
+        },
+      },
+    ],
+
+    // Enforce spacing around colons of switch statements
+    // https://eslint.org/docs/rules/switch-colon-spacing
+    'switch-colon-spacing': ['error', { after: true, before: false }],
+
+    // Require or disallow spacing between template tags and their literals
+    // https://eslint.org/docs/rules/template-tag-spacing
+    'template-tag-spacing': ['error', 'never'],
+
+    // require or disallow the Unicode Byte Order Mark
+    // https://eslint.org/docs/rules/unicode-bom
+    'unicode-bom': ['error', 'never'],
+
+    // require regex literals to be wrapped in parentheses
+    'wrap-regex': 'off',
+  },
+};

--- a/rules/style.js
+++ b/rules/style.js
@@ -7,7 +7,7 @@
  * with the following modifications:
  *
  * - Enable `func-names` rule
- * - Disable `no-nested-ternary` rule
+ * - Disable `no-nested-ternary` rule because there is no problem if you use line breaks and indentation properly.
  * - Enable `no-plusplus` rule with `allowForLoopAfterthoughts` option
  */
 

--- a/rules/style.js
+++ b/rules/style.js
@@ -32,9 +32,11 @@ module.exports = {
     'block-spacing': ['error', 'always'],
 
     // enforce one true brace style
+    // https://eslint.org/docs/rules/brace-style
     'brace-style': ['error', '1tbs', { allowSingleLine: true }],
 
     // require camel case names
+    // https://eslint.org/docs/rules/camelcase
     camelcase: ['error', { properties: 'never', ignoreDestructuring: false }],
 
     // enforce or disallow capitalization of the first letter of a comment
@@ -57,6 +59,7 @@ module.exports = {
     ],
 
     // require trailing commas in multiline object literals
+    // https://eslint.org/docs/rules/comma-dangle
     'comma-dangle': [
       'error',
       {
@@ -69,9 +72,11 @@ module.exports = {
     ],
 
     // enforce spacing before and after comma
+    // https://eslint.org/docs/rules/comma-spacing
     'comma-spacing': ['error', { before: false, after: true }],
 
     // enforce one true comma style
+    // https://eslint.org/docs/rules/comma-style
     'comma-style': [
       'error',
       'last',
@@ -93,12 +98,15 @@ module.exports = {
     ],
 
     // disallow padding inside computed properties
+    // https://eslint.org/docs/rules/computed-property-spacing
     'computed-property-spacing': ['error', 'never'],
 
     // enforces consistent naming when capturing the current execution context
+    // https://eslint.org/docs/rules/consistent-this
     'consistent-this': ['off'],
 
     // enforce newline at the end of file, with no multiple empty lines
+    // https://eslint.org/docs/rules/eol-last
     'eol-last': ['error', 'always'],
 
     // https://eslint.org/docs/rules/function-call-argument-newline
@@ -139,9 +147,11 @@ module.exports = {
 
     // this option enforces minimum and maximum identifier lengths
     // (variable names, property names etc.)
+    // https://eslint.org/docs/rules/id-length
     'id-length': ['off'],
 
     // require identifiers to match the provided regular expression
+    // https://eslint.org/docs/rules/id-match
     'id-match': ['off'],
 
     // Enforce the location of arrow function bodies with implicit returns
@@ -201,9 +211,11 @@ module.exports = {
     'jsx-quotes': ['off', 'prefer-double'],
 
     // enforces spacing between keys and values in object literal properties
+    // https://eslint.org/docs/rules/key-spacing
     'key-spacing': ['error', { beforeColon: false, afterColon: true }],
 
     // require a space before & after certain keywords
+    // https://eslint.org/docs/rules/keyword-spacing
     'keyword-spacing': [
       'error',
       {
@@ -244,6 +256,7 @@ module.exports = {
     ],
 
     // enforces empty lines around comments
+    // https://eslint.org/docs/rules/lines-around-comment
     'lines-around-comment': ['off'],
 
     // require or disallow newlines around directives
@@ -268,6 +281,7 @@ module.exports = {
     ],
 
     // specify the maximum depth that blocks can be nested
+    // https://eslint.org/docs/latest/rules/max-depth
     'max-depth': ['off', 4],
 
     // specify the maximum length of a line in your program
@@ -309,12 +323,15 @@ module.exports = {
     ],
 
     // specify the maximum depth callbacks can be nested
+    // https://eslint.org/docs/rules/max-nested-callbacks
     'max-nested-callbacks': ['off'],
 
     // limits the number of parameters that can be used in the function declaration.
+    // https://eslint.org/docs/rules/max-params
     'max-params': ['off', 3],
 
     // specify the maximum number of statement allowed in a function
+    // https://eslint.org/docs/rules/max-statements
     'max-statements': ['off', 10],
 
     // restrict the number of statements per line
@@ -331,6 +348,7 @@ module.exports = {
     'multiline-ternary': ['off', 'never'],
 
     // require a capital letter for constructors
+    // https://eslint.org/docs/rules/new-cap
     'new-cap': [
       'error',
       {
@@ -350,6 +368,7 @@ module.exports = {
     'new-parens': ['error'],
 
     // allow/disallow an empty newline after var statement
+    // https://eslint.org/docs/rules/newline-after-var
     'newline-after-var': ['off'],
 
     // https://eslint.org/docs/rules/newline-before-return
@@ -361,6 +380,7 @@ module.exports = {
     'newline-per-chained-call': ['error', { ignoreChainWithDepth: 4 }],
 
     // disallow use of the Array constructor
+    // https://eslint.org/docs/rules/no-array-constructor
     'no-array-constructor': ['error'],
 
     // disallow use of bitwise operators
@@ -372,6 +392,7 @@ module.exports = {
     'no-continue': ['error'],
 
     // disallow comments inline after code
+    // https://eslint.org/docs/rules/no-inline-comments
     'no-inline-comments': ['off'],
 
     // disallow if as the only statement in an else block
@@ -401,6 +422,7 @@ module.exports = {
     ],
 
     // disallow mixed spaces and tabs for indentation
+    // https://eslint.org/docs/rules/no-mixed-spaces-and-tabs
     'no-mixed-spaces-and-tabs': ['error'],
 
     // disallow use of chained assignment expressions
@@ -416,9 +438,11 @@ module.exports = {
     'no-negated-condition': ['off'],
 
     // disallow nested ternary expressions
+    // https://eslint.org/docs/rules/no-nested-ternary
     'no-nested-ternary': ['off'],
 
     // disallow use of the Object constructor
+    // https://eslint.org/docs/rules/no-new-object
     'no-new-object': ['error'],
 
     // disallow use of unary operators, ++ and --
@@ -457,12 +481,15 @@ module.exports = {
     ],
 
     // disallow tab characters entirely
+    // https://eslint.org/docs/rules/no-tabs
     'no-tabs': ['error'],
 
     // disallow the use of ternary operators
+    // https://eslint.org/docs/rules/no-ternary
     'no-ternary': ['off'],
 
     // disallow trailing whitespace at the end of lines
+    // https://eslint.org/docs/rules/no-trailing-spaces
     'no-trailing-spaces': [
       'error',
       {
@@ -497,6 +524,7 @@ module.exports = {
     'nonblock-statement-body-position': ['error', 'beside', { overrides: {} }],
 
     // require padding inside curly braces
+    // https://eslint.org/docs/rules/object-curly-spacing
     'object-curly-spacing': ['error', 'always'],
 
     // enforce line breaks between braces
@@ -533,6 +561,7 @@ module.exports = {
     ],
 
     // allow just one var statement per function
+    // https://eslint.org/docs/rules/one-var
     'one-var': ['error', 'never'],
 
     // require a newline around variable declaration
@@ -548,6 +577,7 @@ module.exports = {
     'operator-linebreak': ['error', 'before', { overrides: { '=': 'none' } }],
 
     // disallow padding within blocks
+    // https://eslint.org/docs/rules/padded-blocks
     'padded-blocks': [
       'error',
       {
@@ -581,6 +611,7 @@ module.exports = {
     ],
 
     // specify whether double or single quotes should be used
+    // https://eslint.org/docs/rules/quotes
     quotes: ['error', 'single', { avoidEscape: true }],
 
     // do not require jsdoc
@@ -588,9 +619,11 @@ module.exports = {
     'require-jsdoc': ['off'],
 
     // require or disallow use of semicolons instead of ASI
+    // https://eslint.org/docs/rules/semi
     semi: ['error', 'always'],
 
     // enforce spacing before and after semicolons
+    // https://eslint.org/docs/rules/semi-spacing
     'semi-spacing': ['error', { before: false, after: true }],
 
     // Enforce location of semicolons
@@ -598,12 +631,15 @@ module.exports = {
     'semi-style': ['error', 'last'],
 
     // requires object keys to be sorted
+    // https://eslint.org/docs/rules/sort-keys
     'sort-keys': ['off', 'asc', { caseSensitive: false, natural: true }],
 
     // sort variables within the same declaration block
+    // https://eslint.org/docs/rules/sort-vars
     'sort-vars': ['off'],
 
     // require or disallow space before blocks
+    // https://eslint.org/docs/rules/space-before-blocks
     'space-before-blocks': ['error'],
 
     // require or disallow space before function opening parenthesis
@@ -618,9 +654,11 @@ module.exports = {
     ],
 
     // require or disallow spaces inside parentheses
+    // https://eslint.org/docs/rules/space-in-parens
     'space-in-parens': ['error', 'never'],
 
     // require spaces around operators
+    // https://eslint.org/docs/rules/space-infix-ops
     'space-infix-ops': ['error'],
 
     // Require or disallow spaces before/after unary operators
@@ -665,6 +703,7 @@ module.exports = {
     'unicode-bom': ['error', 'never'],
 
     // require regex literals to be wrapped in parentheses
+    // https://eslint.org/docs/rules/wrap-regex
     'wrap-regex': ['off'],
   },
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -7,7 +7,6 @@
  * with the following modifications:
  *
  * - Enable `func-names` rule
- * - Enable `lines-between-class-members` rule with `exceptAfterSingleLine` option
  * - Disable `no-nested-ternary` rule
  * - Enable `no-plusplus` rule with `allowForLoopAfterthoughts` option
  */
@@ -244,16 +243,6 @@ module.exports = {
     // disallow mixed 'LF' and 'CRLF' as linebreaks
     // https://eslint.org/docs/rules/linebreak-style
     'linebreak-style': ['error', 'unix'],
-
-    // require or disallow an empty line between class members
-    // https://eslint.org/docs/rules/lines-between-class-members
-    'lines-between-class-members': [
-      'error',
-      'always',
-      {
-        exceptAfterSingleLine: true,
-      },
-    ],
 
     // enforces empty lines around comments
     // https://eslint.org/docs/rules/lines-around-comment

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2012 Airbnb
+ *
+ * Licensed under the MIT License: https://github.com/airbnb/javascript/blob/master/LICENSE.md
+ *
+ * This file is a copy of https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js
+ * with the following modifications:
+ *
+ * - Enable `func-names` rule
+ * - Enable `lines-between-class-members` rule with `exceptAfterSingleLine` option
+ * - Disable `no-nested-ternary` rule
+ * - Enable `no-plusplus` rule with `allowForLoopAfterthoughts` option
+ */
+
 module.exports = {
   rules: {
     // enforce line breaks after opening and before closing array brackets
@@ -82,7 +96,7 @@ module.exports = {
     'computed-property-spacing': ['error', 'never'],
 
     // enforces consistent naming when capturing the current execution context
-    'consistent-this': 'off',
+    'consistent-this': ['off'],
 
     // enforce newline at the end of file, with no multiple empty lines
     'eol-last': ['error', 'always'],
@@ -108,7 +122,7 @@ module.exports = {
 
     // require function expressions to have a name
     // https://eslint.org/docs/rules/func-names
-    'func-names': ['error'],
+    'func-names': ['error', 'as-needed'],
 
     // enforces use of function declarations or expressions
     // https://eslint.org/docs/rules/func-style
@@ -121,14 +135,14 @@ module.exports = {
 
     // disallow specified identifiers
     // https://eslint.org/docs/rules/id-denylist
-    'id-denylist': 'off',
+    'id-denylist': ['off'],
 
     // this option enforces minimum and maximum identifier lengths
     // (variable names, property names etc.)
-    'id-length': 'off',
+    'id-length': ['off'],
 
     // require identifiers to match the provided regular expression
-    'id-match': 'off',
+    'id-match': ['off'],
 
     // Enforce the location of arrow function bodies with implicit returns
     // https://eslint.org/docs/rules/implicit-arrow-linebreak
@@ -230,7 +244,7 @@ module.exports = {
     ],
 
     // enforces empty lines around comments
-    'lines-around-comment': 'off',
+    'lines-around-comment': ['off'],
 
     // require or disallow newlines around directives
     // https://eslint.org/docs/rules/lines-around-directive
@@ -239,6 +253,17 @@ module.exports = {
       {
         before: 'always',
         after: 'always',
+      },
+    ],
+
+    // Require or disallow logical assignment logical operator shorthand
+    // https://eslint.org/docs/latest/rules/logical-assignment-operators
+    // TODO, semver-major: enable
+    'logical-assignment-operators': [
+      'off',
+      'always',
+      {
+        enforceForIfStatements: true,
       },
     ],
 
@@ -284,7 +309,7 @@ module.exports = {
     ],
 
     // specify the maximum depth callbacks can be nested
-    'max-nested-callbacks': 'off',
+    'max-nested-callbacks': ['off'],
 
     // limits the number of parameters that can be used in the function declaration.
     'max-params': ['off', 3],
@@ -322,13 +347,13 @@ module.exports = {
 
     // disallow the omission of parentheses when invoking a constructor with no arguments
     // https://eslint.org/docs/rules/new-parens
-    'new-parens': 'error',
+    'new-parens': ['error'],
 
     // allow/disallow an empty newline after var statement
-    'newline-after-var': 'off',
+    'newline-after-var': ['off'],
 
     // https://eslint.org/docs/rules/newline-before-return
-    'newline-before-return': 'off',
+    'newline-before-return': ['off'],
 
     // enforces new line after each method call in the chain to make it
     // more readable and easy to maintain
@@ -336,22 +361,22 @@ module.exports = {
     'newline-per-chained-call': ['error', { ignoreChainWithDepth: 4 }],
 
     // disallow use of the Array constructor
-    'no-array-constructor': 'error',
+    'no-array-constructor': ['error'],
 
     // disallow use of bitwise operators
     // https://eslint.org/docs/rules/no-bitwise
-    'no-bitwise': ['off'],
+    'no-bitwise': ['error'],
 
     // disallow use of the continue statement
     // https://eslint.org/docs/rules/no-continue
-    'no-continue': 'error',
+    'no-continue': ['error'],
 
     // disallow comments inline after code
-    'no-inline-comments': 'off',
+    'no-inline-comments': ['off'],
 
     // disallow if as the only statement in an else block
     // https://eslint.org/docs/rules/no-lonely-if
-    'no-lonely-if': 'error',
+    'no-lonely-if': ['error'],
 
     // disallow un-paren'd mixes of different operators
     // https://eslint.org/docs/rules/no-mixed-operators
@@ -375,6 +400,9 @@ module.exports = {
       },
     ],
 
+    // disallow mixed spaces and tabs for indentation
+    'no-mixed-spaces-and-tabs': ['error'],
+
     // disallow use of chained assignment expressions
     // https://eslint.org/docs/rules/no-multi-assign
     'no-multi-assign': ['error'],
@@ -385,17 +413,22 @@ module.exports = {
 
     // disallow negated conditions
     // https://eslint.org/docs/rules/no-negated-condition
-    'no-negated-condition': 'off',
+    'no-negated-condition': ['off'],
 
     // disallow nested ternary expressions
     'no-nested-ternary': ['off'],
 
     // disallow use of the Object constructor
-    'no-new-object': 'error',
+    'no-new-object': ['error'],
 
     // disallow use of unary operators, ++ and --
     // https://eslint.org/docs/rules/no-plusplus
-    'no-plusplus': ['off'],
+    'no-plusplus': [
+      'error',
+      {
+        allowForLoopAfterthoughts: true,
+      },
+    ],
 
     // disallow certain syntax forms
     // https://eslint.org/docs/rules/no-restricted-syntax
@@ -421,20 +454,13 @@ module.exports = {
         message:
           '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
-      {
-        selector: 'TSEnumDeclaration',
-        message: 'Do not declare enums',
-      },
     ],
 
-    // disallow space between function identifier and application
-    'no-spaced-func': 'error',
-
     // disallow tab characters entirely
-    'no-tabs': 'error',
+    'no-tabs': ['error'],
 
     // disallow the use of ternary operators
-    'no-ternary': 'off',
+    'no-ternary': ['off'],
 
     // disallow trailing whitespace at the end of lines
     'no-trailing-spaces': [
@@ -464,7 +490,7 @@ module.exports = {
 
     // disallow whitespace before properties
     // https://eslint.org/docs/rules/no-whitespace-before-property
-    'no-whitespace-before-property': 'error',
+    'no-whitespace-before-property': ['error'],
 
     // enforce the location of single-line statements
     // https://eslint.org/docs/rules/nonblock-statement-body-position
@@ -536,15 +562,15 @@ module.exports = {
 
     // Require or disallow padding lines between statements
     // https://eslint.org/docs/rules/padding-line-between-statements
-    'padding-line-between-statements': 'off',
+    'padding-line-between-statements': ['off'],
 
     // Disallow the use of Math.pow in favor of the ** operator
     // https://eslint.org/docs/rules/prefer-exponentiation-operator
-    'prefer-exponentiation-operator': 'error',
+    'prefer-exponentiation-operator': ['error'],
 
     // Prefer use of an object spread over Object.assign
     // https://eslint.org/docs/rules/prefer-object-spread
-    'prefer-object-spread': 'error',
+    'prefer-object-spread': ['error'],
 
     // require quotes around object literal property names
     // https://eslint.org/docs/rules/quote-props.html
@@ -559,7 +585,7 @@ module.exports = {
 
     // do not require jsdoc
     // https://eslint.org/docs/rules/require-jsdoc
-    'require-jsdoc': 'off',
+    'require-jsdoc': ['off'],
 
     // require or disallow use of semicolons instead of ASI
     semi: ['error', 'always'],
@@ -575,10 +601,10 @@ module.exports = {
     'sort-keys': ['off', 'asc', { caseSensitive: false, natural: true }],
 
     // sort variables within the same declaration block
-    'sort-vars': 'off',
+    'sort-vars': ['off'],
 
     // require or disallow space before blocks
-    'space-before-blocks': 'error',
+    'space-before-blocks': ['error'],
 
     // require or disallow space before function opening parenthesis
     // https://eslint.org/docs/rules/space-before-function-paren
@@ -595,7 +621,7 @@ module.exports = {
     'space-in-parens': ['error', 'never'],
 
     // require spaces around operators
-    'space-infix-ops': 'error',
+    'space-infix-ops': ['error'],
 
     // Require or disallow spaces before/after unary operators
     // https://eslint.org/docs/rules/space-unary-ops
@@ -639,6 +665,6 @@ module.exports = {
     'unicode-bom': ['error', 'never'],
 
     // require regex literals to be wrapped in parentheses
-    'wrap-regex': 'off',
+    'wrap-regex': ['off'],
   },
 };


### PR DESCRIPTION
## Summary

Implement the ruleset by referring to the [style](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js) of [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base).

However, the following rules are set by us:

- [func-names](https://eslint.org/docs/rules/func-names)
  - Omitting the function name makes debugging difficult.
- [no-nested-ternary](https://eslint.org/docs/rules/no-nested-ternary)
  - Disable it because there is no problem if you use line breaks and indentation properly.
- [no-plusplus](https://eslint.org/docs/rules/no-plusplus)
  - Enable it with `allowForLoopAfterthoughts` option

## Others

Most of these rules are disabled by [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier).

## References

- #188
- [javascript/packages/eslint-config-airbnb-base at master · airbnb/javascript](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base)
- [javascript/packages/eslint-config-airbnb-base/rules/style.js at master · airbnb/javascript](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js)
