### PR TITLE
feat: Implement the rule "variables"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
+        "confusing-browser-globals": "^1.0.11",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-jest-dom": "^4.0.3",
@@ -3084,6 +3085,11 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA=="
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
+    "confusing-browser-globals": "^1.0.11",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-jest-dom": "^4.0.3",

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2012 Airbnb
+ *
+ * Licensed under the MIT License: https://github.com/airbnb/javascript/blob/master/LICENSE.md
+ *
+ * This file is a copy of https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/variables.js
+ * with the following modifications:
+ *
+ * - Disable `no-shadow` rule as it'll also warn about variables with short lifetimes, such as callback function and loop counters.
+ * - Disable `no-undef` rule as it'll also warn about APIs that are even obvious, such as `document` and `window`.
+ * - Disable `no-use-before-define` rule to give priority to writing order that takes readability into account.
+ */
+
+const confusingBrowserGlobals = require('confusing-browser-globals');
+
+module.exports = {
+  rules: {
+    // enforce or disallow variable initializations at definition
+    // https://eslint.org/docs/rules/init-declarations
+    'init-declarations': 'off',
+
+    // disallow the catch clause parameter name being the same as a variable in the outer scope
+    // https://eslint.org/docs/rules/no-catch-shadow
+    'no-catch-shadow': 'off',
+
+    // disallow deletion of variables
+    // https://eslint.org/docs/rules/no-delete-var
+    'no-delete-var': 'error',
+
+    // disallow labels that share a name with a variable
+    // https://eslint.org/docs/rules/no-label-var
+    'no-label-var': 'error',
+
+    // disallow specific globals
+    // https://eslint.org/docs/rules/no-restricted-globals
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'isFinite',
+        message: 'Use Number.isFinite instead.',
+      },
+      {
+        name: 'isNaN',
+        message: 'Use Number.isNaN instead.',
+      },
+    ].concat(
+      confusingBrowserGlobals.map((g) => ({
+        name: g,
+        message: `Use window.${g} instead.`,
+      })),
+    ),
+
+    // disallow declaration of variables already declared in the outer scope
+    // https://eslint.org/docs/rules/no-shadow
+    'no-shadow': 'off',
+
+    // disallow shadowing of names such as arguments
+    // https://eslint.org/docs/rules/no-shadow-restricted-names
+    'no-shadow-restricted-names': 'error',
+
+    // disallow use of undeclared variables unless mentioned in a /*global */ block
+    // https://eslint.org/docs/rules/no-undef
+    'no-undef': 'off',
+
+    // disallow use of undefined when initializing variables
+    // https://eslint.org/docs/rules/no-undef-init
+    'no-undef-init': 'error',
+
+    // disallow use of undefined variable
+    // https://eslint.org/docs/rules/no-undefined
+    'no-undefined': 'off',
+
+    // disallow declaration of variables that are not used in the code
+    // https://eslint.org/docs/rules/no-unused-vars
+    'no-unused-vars': [
+      'error',
+      { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
+    ],
+
+    // disallow use of variables before they are defined
+    // https://eslint.org/docs/latest/rules/no-use-before-define
+    'no-use-before-define': ['off'],
+  },
+};


### PR DESCRIPTION
## Summary

Implement the ruleset by referring to the [variables](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/variables.js) of [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base).

However, the following rules are set by us:

- [no-shadow](https://eslint.org/docs/rules/no-shadow)
  - Disable it as it'll also warn about variables with short lifetimes, such as callback function and loop counters.
- [no-undef](https://eslint.org/docs/rules/no-undef)
  - Disable it as it'll also warn about APIs that are even obvious, such as `document` and `window`.
- [no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define)
  - Disable it to give priority to writing order that takes readability into account.

Also, [confusing-browser-globals](https://www.npmjs.com/package/confusing-browser-globals) is used to cover the global variables that should be specified in the `no-restricted-globals` option. This library is also used in Create React App.

## References

- #189 
- [javascript/packages/eslint-config-airbnb-base/rules/variables.js at master · airbnb/javascript](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/variables.js)
- [confusing-browser-globals - npm](https://www.npmjs.com/package/confusing-browser-globals)