### PR TITLE
feat: Implement v3 rule "promise"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-plugin-jest-dom": "^4.0.3",
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-next": "^0.0.0",
+        "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.10.3"
@@ -4223,6 +4224,17 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-next/-/eslint-plugin-next-0.0.0.tgz",
       "integrity": "sha512-IldNDVb6WNduggwRbYzSGZhaskUwVecJ6fhmqwX01+S1aohwAWNzU4me6y47DDzpD/g0fdayNBGxEdt9vKkUtg=="
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.33.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-next": "^0.0.0",
+    "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.10.3"

--- a/rules/promise.js
+++ b/rules/promise.js
@@ -1,0 +1,16 @@
+module.exports = {
+  plugins: ['promise'],
+  extends: ['plugin:promise/recommended'],
+
+  rules: {
+    // Require returning inside each `then()` to create readable and reusable Promise chains.
+    // https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/always-return.md
+    // In use cases that don't assume a return value, such as `React.Suspense`, this rule can be confusing.
+    'promise/always-return': ['warn', { ignoreLastCallback: true }],
+
+    // Disallow nested `then()` or `catch()` statements.
+    // https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-nesting.md
+    // Disallowing nesting may actually increase complexity.
+    'promise/no-nesting': ['off'],
+  },
+};


### PR DESCRIPTION
## Summary

Implement the ruleset based on [recommend ruleset of eslint-plugin-promise](https://github.com/eslint-community/eslint-plugin-promise/blob/main/index.js#L32-L43).

However, the following rules are set by us:

- [always-return](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/always-return.md)
  - In use cases that don't assume a return value, such as [`React.Suspense`](https://react.dev/reference/react/Suspense), this rule can be confusing. However, it's certainly better to return as much as possible, so only output a `warn`.
- [no-nesting](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-nesting.md)
  - Disallowing nesting may actually increase complexity.

This ruleset depends on [eslint-plugin-promise](https://github.com/eslint-community/eslint-plugin-promise).

## References

- #190 
- [eslint-plugin-promise](https://github.com/eslint-community/eslint-plugin-promise)