### PR TITLE
feat: Implement the rule "react-hooks"

### DIFF
--- a/rules/react-hooks.js
+++ b/rules/react-hooks.js
@@ -1,0 +1,8 @@
+module.exports = {
+  plugins: ['react-hooks'],
+
+  rules: {
+    'react-hooks/exhaustive-deps': ['error'],
+    'react-hooks/rules-of-hooks': ['error'],
+  },
+};

--- a/rules/react-hooks.js
+++ b/rules/react-hooks.js
@@ -2,7 +2,12 @@ module.exports = {
   plugins: ['react-hooks'],
 
   rules: {
+    // Verify the list of the dependencies for Hooks like useEffect and similar.
+    // https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
     'react-hooks/exhaustive-deps': ['error'],
+
+    // Enforce Rules of Hooks.
+    // https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
     'react-hooks/rules-of-hooks': ['error'],
   },
 };


### PR DESCRIPTION
## Summary

Implement the ruleset as `react-hooks`.

This ruleset depends on [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks).

## References

- #196 
- [react/packages/eslint-plugin-react-hooks at main · facebook/react](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks)