### PR TITLE
feat: Implement v3 rule "jesdoc"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-jest-dom": "^5.1.0",
+        "eslint-plugin-jsdoc": "^48.2.1",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
@@ -698,6 +699,19 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "devOptional": true
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.42.0.tgz",
+      "integrity": "sha512-R1w57YlVA6+YE01wch3GPYn6bCsrOV3YW/5oGGE2tmX6JcL9Nr+b5IikrjMPF+v9CV3ay+obImEdsDhovhJrzw==",
+      "dependencies": {
+        "comment-parser": "1.4.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2333,6 +2347,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3322,6 +3344,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4435,6 +4465,58 @@
           "optional": true
         }
       }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "48.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.2.1.tgz",
+      "integrity": "sha512-iUvbcyDZSO/9xSuRv2HQBw++8VkV/pt3UWtX9cpPH0l7GKPq78QC/6+PmyQHHvNZaTjAce6QVciEbnc6J/zH5g==",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.42.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.6.0",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.8.0",
@@ -7131,6 +7213,14 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "dev": true
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9357,6 +9447,25 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg=="
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-jest-dom": "^5.1.0",
+    "eslint-plugin-jsdoc": "^48.2.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",

--- a/rules/jsdoc.js
+++ b/rules/jsdoc.js
@@ -1,0 +1,133 @@
+module.exports = {
+  plugins: ['jsdoc'],
+  extends: ['plugin:jsdoc/recommended-typescript-error'],
+  rules: {
+    // Checks for dupe @param names, that nested param names have roots, and that parameter names in function declarations match jsdoc param names.
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-param-names.md
+    'jsdoc/check-param-names': [
+      'error',
+      {
+        checkDestructured: false,
+      },
+    ],
+
+    // Reports invalid jsdoc (block) tag names.
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-tag-names.md
+    'jsdoc/check-tag-names': [
+      'error',
+      {
+        // Enable additional tags from TSDoc.
+        definedTags: ['remarks', 'typeParam'],
+      },
+    ],
+
+    // Requires that all functions (and potentially other contexts) have a description.
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-description.md
+    'jsdoc/require-description': [
+      'error',
+      {
+        contexts: [
+          'ArrowFunctionExpression',
+          'ClassDeclaration',
+          'ClassExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+          'MethodDefinition',
+          'PropertyDefinition',
+          'VariableDeclaration',
+          'TSInterfaceDeclaration',
+          'TSTypeAliasDeclaration',
+          'TSPropertySignature',
+          'TSMethodSignature',
+        ],
+      },
+    ],
+
+    // Requires a hyphen before `@param` descriptions (and optionally before `@property` descriptions)
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-hyphen-before-param-description.md
+    'jsdoc/require-hyphen-before-param-description': ['error', 'always'],
+
+    // Checks for presence of jsdoc comments, on functions and potentially other contexts (optionally limited to exports).
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-jsdoc.md
+    'jsdoc/require-jsdoc': [
+      'error',
+      {
+        publicOnly: true,
+        require: {
+          ArrowFunctionExpression: true,
+          ClassDeclaration: true,
+          ClassExpression: true,
+          FunctionDeclaration: true,
+          FunctionExpression: true,
+          MethodDefinition: true,
+        },
+        contexts: [
+          'PropertyDefinition',
+          'VariableDeclaration',
+          'TSInterfaceDeclaration',
+          'TSTypeAliasDeclaration',
+          'TSPropertySignature',
+          'TSMethodSignature',
+        ],
+        checkConstructors: false,
+      },
+    ],
+
+    // Requires that all function parameters are documented with a `@param` tag.
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-param.md
+    'jsdoc/require-param': [
+      'error',
+      {
+        checkDestructuredRoots: false,
+      },
+    ],
+
+    // Enforces lines (or no lines) between tags
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/tag-lines.md
+    'jsdoc/tag-lines': [
+      'error',
+      'always',
+      {
+        startLines: 1,
+        applyToEndTag: false,
+      },
+    ],
+
+    // Sorts tags by a specified sequence according to tag name, optionally adding line breaks between tag groups
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/sort-tags.md
+    'jsdoc/sort-tags': [
+      'error',
+      {
+        reportIntraTagGroupSpacing: false,
+      },
+    ],
+
+    // Requires that return statements are documented.
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-returns.md
+    // TypeScript's completion function is sufficient.
+    'jsdoc/require-returns': ['off'],
+  },
+
+  overrides: [
+    {
+      files: ['*.@(js|cjs|mjs)'],
+      rules: {
+        // Requires that each `@param` tag has a type value (within curly brackets).
+        // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-param-type.md
+        'jsdoc/require-param-type': ['error'],
+
+        // Requires that return statements are documented.
+        // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-returns.md
+        'jsdoc/require-returns': ['error'],
+
+        // Requires that `@returns` tag has a type value (in curly brackets).
+        // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-returns-type.md
+        'jsdoc/require-returns-type': ['error'],
+
+        // Prohibits types on `@param` or `@returns` (redundant with TypeScript)
+        // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/no-types.md
+        'jsdoc/no-types': ['off'],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Implement the ruleset based on [recommend ruleset of eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/index.js#L255) and [my article written on Zenn](https://zenn.dev/wakamsha/articles/setup-eslint-plugin-jsdoc).

This ruleset depends on [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc).

## References

- #197 
- [gajus/eslint-plugin-jsdoc: JSDoc specific linting rules for ESLint.](https://github.com/gajus/eslint-plugin-jsdoc)
- [ESLint を使って JSDoc / TSDoc の記述を必須化する](https://zenn.dev/wakamsha/articles/setup-eslint-plugin-jsdoc)