### PR TITLE
feat: Implement v3 rule "typescript"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "^14.1.3",
-        "@typescript-eslint/eslint-plugin": "^5.59.0",
-        "@typescript-eslint/parser": "^5.59.0",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
         "confusing-browser-globals": "^1.0.11",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.29.1",
@@ -1908,36 +1908,159 @@
       "devOptional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/type-utils": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
@@ -1949,6 +2072,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
@@ -1971,30 +2108,173 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
       }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
@@ -2013,30 +2293,196 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
       }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
@@ -7674,11 +8120,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g=="
-    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -9785,6 +10226,17 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
     },
     "node_modules/ts-dedent": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "homepage": "https://github.com/moneyforward/eslint-config-moneyforward#readme",
   "dependencies": {
     "@next/eslint-plugin-next": "^14.1.3",
-    "@typescript-eslint/eslint-plugin": "^5.59.0",
-    "@typescript-eslint/parser": "^5.59.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
     "confusing-browser-globals": "^1.0.11",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.29.1",

--- a/rules/style.js
+++ b/rules/style.js
@@ -453,11 +453,6 @@ module.exports = {
           'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
       },
       {
-        selector: 'ForOfStatement',
-        message:
-          'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
-      },
-      {
         selector: 'LabeledStatement',
         message:
           'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,4 +1,138 @@
+const { rules: baseBestPracticesRules } = require('./best-practices');
+const { rules: baseVariablesRules } = require('./variables');
+
 module.exports = {
-  extends: ['../configs/typescript'].map(require.resolve),
-  rules: {},
+  extends: [
+    'plugin:@typescript-eslint/strict-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
+
+  rules: {
+    // https://typescript-eslint.io/rules/dot-notation/
+    '@typescript-eslint/dot-notation': baseBestPracticesRules['dot-notation'],
+
+    // https://typescript-eslint.io/rules/no-unused-expressions/
+    // Replace 'no-unused-expressions' rule with '@typescript-eslint' version
+    'no-unused-expressions': 'off',
+    '@typescript-eslint/no-unused-expressions':
+      baseBestPracticesRules['no-unused-expressions'],
+
+    // https://typescript-eslint.io/rules/prefer-promise-reject-errors/
+    // require using Error objects as Promise rejection reasons
+    '@typescript-eslint/prefer-promise-reject-errors':
+      baseBestPracticesRules['prefer-promise-reject-errors'],
+
+    // https://typescript-eslint.io/rules/no-throw-literal/
+    // Replace 'no-throw-literal' rule with '@typescript-eslint' version
+    // TODO: Disable this rule if you are using the React.Suspense.
+    '@typescript-eslint/no-throw-literal':
+      baseBestPracticesRules['no-throw-literal'],
+
+    // https://typescript-eslint.io/rules/naming-convention/
+    // Replace 'camelcase' rule with '@typescript-eslint/naming-convention'
+    camelcase: 'off',
+    // The `@typescript-eslint/naming-convention` rule allows `leadingUnderscore` and `trailingUnderscore` settings.
+    // However, the existing `no-underscore-dangle` rule already takes care of this.
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'variable',
+        format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+      },
+      {
+        selector: 'function',
+        format: ['camelCase', 'PascalCase'],
+      },
+      {
+        selector: 'typeLike',
+        format: ['PascalCase'],
+      },
+    ],
+
+    // https://typescript-eslint.io/rules/no-use-before-define/
+    // Replace 'no-use-before-define' rule with '@typescript-eslint' version.
+    'no-use-before-define': ['off'],
+    '@typescript-eslint/no-use-before-define':
+      baseVariablesRules['no-use-before-define'],
+
+    // https://typescript-eslint.io/rules/consistent-type-definitions/
+    '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+
+    // https://typescript-eslint.io/rules/consistent-type-imports/
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        fixStyle: 'inline-type-imports',
+      },
+    ],
+
+    // https://typescript-eslint.io/rules/no-floating-promises/
+    '@typescript-eslint/no-floating-promises': [
+      'error',
+      {
+        ignoreIIFE: true,
+      },
+    ],
+
+    // https://typescript-eslint.io/rules/no-misused-promises/
+    '@typescript-eslint/no-misused-promises': [
+      'error',
+      {
+        checksVoidReturn: false,
+      },
+    ],
+
+    // https://typescript-eslint.io/rules/restrict-template-expressions/
+    '@typescript-eslint/restrict-template-expressions': [
+      'error',
+      {
+        allowBoolean: true,
+      },
+    ],
+
+    // https://typescript-eslint.io/rules/switch-exhaustiveness-check/
+    '@typescript-eslint/switch-exhaustiveness-check': ['error'],
+
+    // https://typescript-eslint.io/rules/explicit-function-return-type/
+    '@typescript-eslint/explicit-function-return-type': ['off'],
+
+    // https://typescript-eslint.io/rules/explicit-module-boundary-types/
+    '@typescript-eslint/explicit-module-boundary-types': ['off'],
+
+    // https://typescript-eslint.io/rules/no-explicit-any/
+    '@typescript-eslint/no-explicit-any': ['off'],
+
+    // https://typescript-eslint.io/rules/no-unsafe-assignment/
+    '@typescript-eslint/no-unsafe-assignment': ['warn'],
+
+    // https://typescript-eslint.io/rules/no-unsafe-call/
+    '@typescript-eslint/no-unsafe-call': ['warn'],
+
+    // https://typescript-eslint.io/rules/no-unsafe-argument/
+    '@typescript-eslint/no-unsafe-argument': ['warn'],
+
+    // https://typescript-eslint.io/rules/no-unsafe-member-access/
+    '@typescript-eslint/no-unsafe-member-access': ['warn'],
+
+    // https://typescript-eslint.io/rules/non-nullable-type-assertion-style/
+    // You should use type assertion style "as" instead of non-null assertion style.
+    '@typescript-eslint/non-nullable-type-assertion-style': ['off'],
+
+    // https://typescript-eslint.io/rules/prefer-for-of/
+    // "for-of" is prohibited with "no-restricted-syntax". The for statement uses an index-based syntax.
+    '@typescript-eslint/prefer-for-of': ['off'],
+  },
+
+  overrides: [
+    {
+      files: ['*.@(js|cjs|mjs)'],
+      rules: {
+        // https://typescript-eslint.io/rules/ban-ts-comment/
+        '@typescript-eslint/ban-ts-comment': ['off'],
+
+        // https://typescript-eslint.io/rules/ban-ts-comment/
+        '@typescript-eslint/no-var-requires': ['off'],
+      },
+    },
+  ],
 };

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,6 +1,15 @@
 const { rules: baseBestPracticesRules } = require('./best-practices');
 const { rules: baseVariablesRules } = require('./variables');
 
+/**
+ * @remarks
+ * The following rules are too strict and may reduce productivity, so they are specified as 'warn'.
+ *
+ * - no-unsafe-assignment
+ * - no-unsafe-call
+ * - no-unsafe-argument
+ * - no-unsafe-member-access
+ */
 module.exports = {
   extends: [
     'plugin:@typescript-eslint/strict-type-checked',
@@ -63,6 +72,7 @@ module.exports = {
 
     // Enforce type definitions to consistently use either `interface` or `type`.
     // https://typescript-eslint.io/rules/consistent-type-definitions/
+    // 'Interface' has less functionality than 'type alias', so 'type' is recommended.
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
 
     // Enforce consistent usage of type imports.
@@ -70,6 +80,8 @@ module.exports = {
     '@typescript-eslint/consistent-type-imports': [
       'error',
       {
+        // It's preferable to use inline type imports to avoid redundant import lines.
+        // This feature is available in TypeScript 4.5 and later.
         fixStyle: 'inline-type-imports',
       },
     ],
@@ -79,6 +91,7 @@ module.exports = {
     '@typescript-eslint/no-floating-promises': [
       'error',
       {
+        // Allow use of immediate functions because this may be needed within `React.useEffect`.
         ignoreIIFE: true,
       },
     ],
@@ -88,6 +101,7 @@ module.exports = {
     '@typescript-eslint/no-misused-promises': [
       'error',
       {
+        // Strict checks on promises with no return value are excessive. It's' extremely rare for this to cause a bug.
         checksVoidReturn: false,
       },
     ],
@@ -103,10 +117,13 @@ module.exports = {
 
     // Require switch-case statements to be exhaustive.
     // https://typescript-eslint.io/rules/switch-exhaustiveness-check/
+    // When using union type in the conditional expression of a switch statement,
+    // there must be no missing cases (it is OK if `default` is written)
     '@typescript-eslint/switch-exhaustiveness-check': ['error'],
 
     // Require explicit return types on functions and class methods.
     // https://typescript-eslint.io/rules/explicit-function-return-type/
+    // Type inference is sufficient for return type.
     '@typescript-eslint/explicit-function-return-type': ['off'],
 
     // Require explicit return and argument types on exported functions' and classes' public class methods.

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -8,26 +8,31 @@ module.exports = {
   ],
 
   rules: {
+    // Enforce dot notation whenever possible.
     // https://typescript-eslint.io/rules/dot-notation/
     '@typescript-eslint/dot-notation': baseBestPracticesRules['dot-notation'],
 
+    // Disallow unused expressions.
     // https://typescript-eslint.io/rules/no-unused-expressions/
     // Replace 'no-unused-expressions' rule with '@typescript-eslint' version
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions':
       baseBestPracticesRules['no-unused-expressions'],
 
+    // Require using Error objects as Promise rejection reasons.
     // https://typescript-eslint.io/rules/prefer-promise-reject-errors/
     // require using Error objects as Promise rejection reasons
     '@typescript-eslint/prefer-promise-reject-errors':
       baseBestPracticesRules['prefer-promise-reject-errors'],
 
+    // Disallow throwing literals as exceptions.
     // https://typescript-eslint.io/rules/no-throw-literal/
     // Replace 'no-throw-literal' rule with '@typescript-eslint' version
     // TODO: Disable this rule if you are using the React.Suspense.
     '@typescript-eslint/no-throw-literal':
       baseBestPracticesRules['no-throw-literal'],
 
+    // Enforce naming conventions for everything across a codebase.
     // https://typescript-eslint.io/rules/naming-convention/
     // Replace 'camelcase' rule with '@typescript-eslint/naming-convention'
     camelcase: 'off',
@@ -49,15 +54,18 @@ module.exports = {
       },
     ],
 
+    // Disallow the use of variables before they are defined.
     // https://typescript-eslint.io/rules/no-use-before-define/
     // Replace 'no-use-before-define' rule with '@typescript-eslint' version.
     'no-use-before-define': ['off'],
     '@typescript-eslint/no-use-before-define':
       baseVariablesRules['no-use-before-define'],
 
+    // Enforce type definitions to consistently use either `interface` or `type`.
     // https://typescript-eslint.io/rules/consistent-type-definitions/
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
 
+    // Enforce consistent usage of type imports.
     // https://typescript-eslint.io/rules/consistent-type-imports/
     '@typescript-eslint/consistent-type-imports': [
       'error',
@@ -66,6 +74,7 @@ module.exports = {
       },
     ],
 
+    // Require Promise-like statements to be handled appropriately.
     // https://typescript-eslint.io/rules/no-floating-promises/
     '@typescript-eslint/no-floating-promises': [
       'error',
@@ -74,6 +83,7 @@ module.exports = {
       },
     ],
 
+    // Disallow Promises in places not designed to handle them.
     // https://typescript-eslint.io/rules/no-misused-promises/
     '@typescript-eslint/no-misused-promises': [
       'error',
@@ -82,6 +92,7 @@ module.exports = {
       },
     ],
 
+    // Enforce template literal expressions to be of `string` type.
     // https://typescript-eslint.io/rules/restrict-template-expressions/
     '@typescript-eslint/restrict-template-expressions': [
       'error',
@@ -90,46 +101,53 @@ module.exports = {
       },
     ],
 
+    // Require switch-case statements to be exhaustive.
     // https://typescript-eslint.io/rules/switch-exhaustiveness-check/
     '@typescript-eslint/switch-exhaustiveness-check': ['error'],
 
+    // Require explicit return types on functions and class methods.
     // https://typescript-eslint.io/rules/explicit-function-return-type/
     '@typescript-eslint/explicit-function-return-type': ['off'],
 
+    // Require explicit return and argument types on exported functions' and classes' public class methods.
     // https://typescript-eslint.io/rules/explicit-module-boundary-types/
     '@typescript-eslint/explicit-module-boundary-types': ['off'],
 
+    // Disallow the `any` type.
     // https://typescript-eslint.io/rules/no-explicit-any/
-    '@typescript-eslint/no-explicit-any': ['off'],
+    '@typescript-eslint/no-explicit-any': ['warn', { ignoreRestArgs: true }],
 
+    // Disallow assigning a value with type `any` to variables and properties.
     // https://typescript-eslint.io/rules/no-unsafe-assignment/
     '@typescript-eslint/no-unsafe-assignment': ['warn'],
 
+    // Disallow calling a value with type `any`.
     // https://typescript-eslint.io/rules/no-unsafe-call/
     '@typescript-eslint/no-unsafe-call': ['warn'],
 
+    // Disallow calling a function with a value with type `any`.
     // https://typescript-eslint.io/rules/no-unsafe-argument/
     '@typescript-eslint/no-unsafe-argument': ['warn'],
 
+    // Disallow member access on a value with type `any`.
     // https://typescript-eslint.io/rules/no-unsafe-member-access/
     '@typescript-eslint/no-unsafe-member-access': ['warn'],
 
+    // Enforce non-null assertions over explicit type casts.
     // https://typescript-eslint.io/rules/non-nullable-type-assertion-style/
     // You should use type assertion style "as" instead of non-null assertion style.
     '@typescript-eslint/non-nullable-type-assertion-style': ['off'],
-
-    // https://typescript-eslint.io/rules/prefer-for-of/
-    // "for-of" is prohibited with "no-restricted-syntax". The for statement uses an index-based syntax.
-    '@typescript-eslint/prefer-for-of': ['off'],
   },
 
   overrides: [
     {
       files: ['*.@(js|cjs|mjs)'],
       rules: {
+        // Disallow `@ts-<directive>` comments or require descriptions after directives.
         // https://typescript-eslint.io/rules/ban-ts-comment/
         '@typescript-eslint/ban-ts-comment': ['off'],
 
+        // Disallow `require` statements except in import statements.
         // https://typescript-eslint.io/rules/ban-ts-comment/
         '@typescript-eslint/no-var-requires': ['off'],
       },

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -106,15 +106,6 @@ module.exports = {
       },
     ],
 
-    // Enforce template literal expressions to be of `string` type.
-    // https://typescript-eslint.io/rules/restrict-template-expressions/
-    '@typescript-eslint/restrict-template-expressions': [
-      'error',
-      {
-        allowBoolean: true,
-      },
-    ],
-
     // Require switch-case statements to be exhaustive.
     // https://typescript-eslint.io/rules/switch-exhaustiveness-check/
     // When using union type in the conditional expression of a switch statement,


### PR DESCRIPTION
## Summary

Implement the ruleset based on [recommend ruleset of typescript-eslint](https://typescript-eslint.io/users/configs/#recommended-configurations).

This ruleset depends on [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint).

## Details

In #216, the option set to [`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax) and [`@typescript-eslint/prefer-for-of`](https://typescript-eslint.io/rules/prefer-for-of) conflicted, so the setting for `for-of` was deleted from `no-restricted-syntax` options.

## References

- #199 
- #216
- [typescript-eslint/typescript-eslint: ✨ Monorepo for all the tooling which enables ESLint to support TypeScript](https://github.com/typescript-eslint/typescript-eslint)
- [no-restricted-syntax - ESLint - Pluggable JavaScript Linter](https://eslint.org/docs/latest/rules/no-restricted-syntax)
- [prefer-for-of | typescript-eslint](https://typescript-eslint.io/rules/prefer-for-of/)