### PR TITLE
feat: Implement v3 config "storybook"

### DIFF
--- a/configs/storybook.js
+++ b/configs/storybook.js
@@ -1,0 +1,8 @@
+module.exports = {
+  overrides: [
+    {
+      extends: ['../rules/storybook'],
+      files: ['*.stories.@(ts|tsx|js|jsx)', '*.story.@(ts|tsx|js|jsx)'],
+    },
+  ],
+};

--- a/configs/storybook.js
+++ b/configs/storybook.js
@@ -2,7 +2,11 @@ module.exports = {
   overrides: [
     {
       extends: ['../rules/storybook'],
-      files: ['*.stories.@(ts|tsx|js|jsx)', '*.story.@(ts|tsx|js|jsx)'],
+      files: [
+        '*.stories.@(ts|tsx|js|jsx)',
+        '*.story.@(ts|tsx|js|jsx)',
+        '**/.storybook/**/*.@(ts|tsx|js|jsx)',
+      ],
     },
   ],
 };

--- a/rules/storybook.js
+++ b/rules/storybook.js
@@ -12,17 +12,4 @@ module.exports = {
     // Starting in CSF 3.0, story titles can be generated automatically.
     'storybook/no-title-property-in-meta': 'error',
   },
-
-  overrides: [
-    {
-      files: [
-        '*.stories.@(ts|tsx|js|jsx)',
-        '*.story.@(ts|tsx|js|jsx)',
-        '**/.storybook/**/*.@(ts|tsx|js|jsx)',
-      ],
-      rules: {
-        'import/no-default-export': ['off'],
-      },
-    },
-  ],
 };

--- a/rules/storybook.js
+++ b/rules/storybook.js
@@ -12,4 +12,17 @@ module.exports = {
     // Starting in CSF 3.0, story titles can be generated automatically.
     'storybook/no-title-property-in-meta': 'error',
   },
+
+  overrides: [
+    {
+      files: [
+        '*.stories.@(ts|tsx|js|jsx)',
+        '*.story.@(ts|tsx|js|jsx)',
+        '**/.storybook/**/*.@(ts|tsx|js|jsx)',
+      ],
+      rules: {
+        'import/no-default-export': ['off'],
+      },
+    },
+  ],
 };


### PR DESCRIPTION
## Summary

Implement a config (preset) that aggregates the following rules:

- [rules/storybook](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/rules/storybook.js)

This config is only applied the files that match one of the following condition:

- `*.stories.@(ts|tsx|js|jsx)`
- `*.story.@(ts|tsx|js|jsx)`
- `**/.storybook/**/*.@(ts|tsx|js|jsx)`

## Details

Since Storybook related files require `default export`, disable the related rule enabled in #213 for these only.

## References

- #205