### PR TITLE
feat: Implement v3 config "typescript"

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,16 +1,9 @@
 module.exports = {
   overrides: [
     {
-      files: ['**/*.ts?(x)'],
-      extends: [
-        // https://github.com/typescript-eslint/typescript-eslint/blob/8cfe93372e1d826e54febc3aeb7047c792b90963/packages/eslint-plugin/src/configs/recommended.ts
-        'plugin:@typescript-eslint/recommended',
-      ],
-      plugins: ['@typescript-eslint'],
+      extends: ['../rules/typescript'],
+      files: ['*.@(ts|tsx|cts|mts)'],
       parser: '@typescript-eslint/parser',
-      parserOptions: {
-        sourceType: 'module',
-      },
     },
   ],
 };

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -11,6 +11,7 @@ const { rules: baseVariablesRules } = require('./variables');
  * - no-unsafe-member-access
  */
 module.exports = {
+  plugins: ['@typescript-eslint'],
   extends: [
     'plugin:@typescript-eslint/strict-type-checked',
     'plugin:@typescript-eslint/stylistic-type-checked',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -147,19 +147,4 @@ module.exports = {
     // You should use type assertion style "as" instead of non-null assertion style.
     '@typescript-eslint/non-nullable-type-assertion-style': ['off'],
   },
-
-  overrides: [
-    {
-      files: ['*.@(js|cjs|mjs)'],
-      rules: {
-        // Disallow `@ts-<directive>` comments or require descriptions after directives.
-        // https://typescript-eslint.io/rules/ban-ts-comment/
-        '@typescript-eslint/ban-ts-comment': ['off'],
-
-        // Disallow `require` statements except in import statements.
-        // https://typescript-eslint.io/rules/ban-ts-comment/
-        '@typescript-eslint/no-var-requires': ['off'],
-      },
-    },
-  ],
 };


### PR DESCRIPTION
## Summary

Implement a config (preset) that aggregates the following rules:

- [rules/typescript](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/rules/typescript.js)

This config is only applied the files that match the following condition:

- `*.@(ts|tsx|cts|mts)`

## References

- #207