### PR TITLE
feat: Implement v3 config "next"

### DIFF
--- a/configs/next.js
+++ b/configs/next.js
@@ -1,8 +1,3 @@
 module.exports = {
-  extends: [
-    require.resolve('./react'),
-    // https://github.com/vercel/next.js/blob/6f420962338fb99a377bde8e1e663bc202c95b68/packages/eslint-plugin-next/lib/index.js
-    'plugin:@next/next/recommended',
-  ],
-  plugins: ['@next/next'],
+  extends: ['../rules/next'],
 };

--- a/rules/next.js
+++ b/rules/next.js
@@ -5,5 +5,13 @@ module.exports = {
     // https://github.com/vercel/next.js/blob/v14.1.3/packages/eslint-plugin-next/src/index.ts#L56
     'plugin:@next/next/core-web-vitals',
   ],
-  rules: {},
+
+  overrides: [
+    {
+      files: ['**/pages/**/*.@(tsx|jsx)', '*.page.@(tsx|jsx)'],
+      rules: {
+        'import/no-default-export': ['off'],
+      },
+    },
+  ],
 };

--- a/rules/next.js
+++ b/rules/next.js
@@ -11,7 +11,9 @@ module.exports = {
       files: [
         '**/pages/**/*.@(tsx|jsx|js)',
         '*.page.@(tsx|jsx|js)',
-        '**/app/**/@(page|layout).@(tsx|jsx|js)',
+        // Files with these names allow `default export` according to the Next.js specifications.
+        // https://nextjs.org/docs/app/api-reference/file-conventions
+        '**/app/**/@(default|error|layout|loading|middleware|not\\-found|page|template).*',
       ],
       rules: {
         'import/no-default-export': ['off'],

--- a/rules/next.js
+++ b/rules/next.js
@@ -8,7 +8,11 @@ module.exports = {
 
   overrides: [
     {
-      files: ['**/pages/**/*.@(tsx|jsx)', '*.page.@(tsx|jsx)'],
+      files: [
+        '**/pages/**/*.@(tsx|jsx|js)',
+        '*.page.@(tsx|jsx|js)',
+        '**/app/**/@(page|layout).@(tsx|jsx|js)',
+      ],
       rules: {
         'import/no-default-export': ['off'],
       },

--- a/rules/next.js
+++ b/rules/next.js
@@ -8,13 +8,7 @@ module.exports = {
 
   overrides: [
     {
-      files: [
-        '**/pages/**/*.@(tsx|jsx|js)',
-        '*.page.@(tsx|jsx|js)',
-        // Files with these names allow `default export` according to the Next.js specifications.
-        // https://nextjs.org/docs/app/api-reference/file-conventions
-        '**/app/**/@(default|error|layout|loading|middleware|not\\-found|page|template).*',
-      ],
+      files: ['**/@(app|pages)/**/*', '*.page.@(tsx|jsx|js)'],
       rules: {
         'import/no-default-export': ['off'],
       },


### PR DESCRIPTION
## Summary

Implement a config (preset) that aggregates the following rules:

- [rules/next](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/rules/next.js)

## Details

Since page files require default export, disable the related rule enabled in https://github.com/moneyforward/eslint-config-moneyforward/pull/213 for these only.

## References

- #202 