### PR TITLE
chore: Remove unnecessary configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  extends: ['./configs/base', './configs/node', './configs/jest.js'].map(
-    require.resolve,
-  ),
+  extends: ['./configs/essentials', './configs/node'].map(require.resolve),
 };

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,9 +1,0 @@
-module.exports = {
-  env: {
-    browser: true,
-  },
-  extends: [
-    // https://github.com/eslint/eslint/blob/f113cdd872257d72bbd66d95e4eaf13623323b24/conf/eslint-recommended.js
-    'eslint:recommended',
-  ],
-};

--- a/configs/prettier.js
+++ b/configs/prettier.js
@@ -1,6 +1,0 @@
-module.exports = {
-  extends: [
-    // https://github.com/prettier/eslint-config-prettier
-    'prettier',
-  ],
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "confusing-browser-globals": "^1.0.11",
-        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-jest-dom": "^5.1.0",
@@ -4742,17 +4741,6 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-config-prettier": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "confusing-browser-globals": "^1.0.11",
-    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-jest-dom": "^5.1.0",


### PR DESCRIPTION
## Summary

Uninstall the following unnecessary config files:

- `config/base`:
  - this file is replaced by [`config/essentials`](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/essentials.js)
- `config/prettier`:
  - This setting must be prepared by the user of Prettier.

Also updated the `.eslintrc` configuration for this repository.

## References

- [Design Overview of eslint-config-moneyforward 3 · moneyforward/eslint-config-moneyforward · Discussion #182](https://github.com/moneyforward/eslint-config-moneyforward/discussions/182#:~:text=Projects%20formatting%20code%20with%20Prettier%20must%20also%20install%20eslint%2Dconfig%2Dprettier.%20By%20loading%20this%20additionally%2C%20you%20can%20disable%20ESLint%20rulesets%20that%20conflict%20with%20Prettier.)