### PR TITLE
chore: Update package settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,20 @@
         "eslint-plugin-testing-library": "^5.11.1"
       },
       "devDependencies": {
-        "eslint": "^8.38.0",
+        "eslint": "^7.32.0 || ^8.2.0",
         "jest": "^29.5.0",
         "prettier": "^2.8.7",
-        "release-it": "^15.10.1"
+        "release-it": "^15.10.1",
+        "typescript": ">= 4.2.4 || ^5.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=7",
-        "typescript": ">=4"
+        "eslint": "^7.32.0 || ^8.2.0",
+        "typescript": ">= 4.2.4 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10395,7 +10401,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,23 +26,14 @@
         "eslint-plugin-testing-library": "^5.11.1"
       },
       "devDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint": "^8.38.0",
         "jest": "^29.5.0",
         "prettier": "^2.8.7",
-        "release-it": "^15.10.1",
-        "typescript": ">= 4.2.4 || ^5.0.0"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
+        "release-it": "^15.10.1"
       },
       "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "typescript": ">= 4.2.4 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": ">=7",
+        "typescript": ">=4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10404,6 +10395,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,23 @@
         "eslint-plugin-testing-library": "^5.11.1"
       },
       "devDependencies": {
-        "eslint": "^8.38.0",
+        "eslint": "^7.32.0 || ^8.2.0",
         "jest": "^29.5.0",
         "prettier": "^2.8.7",
-        "release-it": "^15.10.1"
+        "release-it": "^15.10.1",
+        "typescript": ">= 4.2.4 || ^5.0.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=7",
-        "typescript": ">=4"
+        "eslint": "^7.32.0 || ^8.2.0",
+        "typescript": ">= 4.2.4 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10395,7 +10404,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "eslint-config-moneyforward",
   "version": "2.0.0",
   "description": "Money Forward's ESLint rules as an extensible shared config.",
-  "main": "rules/index.js",
   "scripts": {
     "lint": "eslint && prettier --check .",
     "lint:fix": "eslint --fix && prettier --write .",
@@ -37,13 +36,19 @@
     "eslint-plugin-testing-library": "^5.11.1"
   },
   "devDependencies": {
-    "eslint": "^8.38.0",
+    "eslint": "^7.32.0 || ^8.2.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
-    "release-it": "^15.10.1"
+    "release-it": "^15.10.1",
+    "typescript": ">= 4.2.4 || ^5.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7",
-    "typescript": ">=4"
+    "eslint": "^7.32.0 || ^8.2.0",
+    "typescript": ">= 4.2.4 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,19 @@
   "name": "eslint-config-moneyforward",
   "version": "2.0.0",
   "description": "Money Forward's ESLint rules as an extensible shared config.",
-  "main": "rules/index.js",
+  "exports": {
+    "./essentials": "./configs/essentials.js",
+    "./jsdoc": "./configs/jsdoc.js",
+    "./next": "./configs/next.js",
+    "./node": "./configs/node.js",
+    "./react": "./configs/react.js",
+    "./storybook": "./configs/storybook.js",
+    "./test/*": "./configs/test/*.js",
+    "./typescript": "./configs/typescript.js"
+  },
+  "engines": {
+    "node": ">= 18.0.0"
+  },
   "scripts": {
     "lint": "eslint && prettier --check .",
     "lint:fix": "eslint --fix && prettier --write .",
@@ -37,13 +49,19 @@
     "eslint-plugin-testing-library": "^5.11.1"
   },
   "devDependencies": {
-    "eslint": "^8.38.0",
+    "eslint": "^7.32.0 || ^8.2.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
-    "release-it": "^15.10.1"
+    "release-it": "^15.10.1",
+    "typescript": ">= 4.2.4 || ^5.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7",
-    "typescript": ">=4"
+    "eslint": "^7.32.0 || ^8.2.0",
+    "typescript": ">= 4.2.4 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,19 +2,7 @@
   "name": "eslint-config-moneyforward",
   "version": "2.0.0",
   "description": "Money Forward's ESLint rules as an extensible shared config.",
-  "exports": {
-    "./essentials": "./configs/essentials.js",
-    "./jsdoc": "./configs/jsdoc.js",
-    "./next": "./configs/next.js",
-    "./node": "./configs/node.js",
-    "./react": "./configs/react.js",
-    "./storybook": "./configs/storybook.js",
-    "./test/*": "./configs/test/*.js",
-    "./typescript": "./configs/typescript.js"
-  },
-  "engines": {
-    "node": ">= 18.0.0"
-  },
+  "main": "rules/index.js",
   "scripts": {
     "lint": "eslint && prettier --check .",
     "lint:fix": "eslint --fix && prettier --write .",
@@ -49,19 +37,13 @@
     "eslint-plugin-testing-library": "^5.11.1"
   },
   "devDependencies": {
-    "eslint": "^7.32.0 || ^8.2.0",
+    "eslint": "^8.38.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
-    "release-it": "^15.10.1",
-    "typescript": ">= 4.2.4 || ^5.0.0"
+    "release-it": "^15.10.1"
   },
   "peerDependencies": {
-    "eslint": "^7.32.0 || ^8.2.0",
-    "typescript": ">= 4.2.4 || ^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
+    "eslint": ">=7",
+    "typescript": ">=4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "eslint-config-moneyforward",
   "version": "2.0.0",
   "description": "Money Forward's ESLint rules as an extensible shared config.",
+  "exports": {
+    "./essentials": "./configs/essentials.js",
+    "./jsdoc": "./configs/jsdoc.js",
+    "./next": "./configs/next.js",
+    "./node": "./configs/node.js",
+    "./react": "./configs/react.js",
+    "./storybook": "./configs/storybook.js",
+    "./test/*": "./configs/test/*.js",
+    "./typescript": "./configs/typescript.js"
+  },
   "engines": {
     "node": ">= 18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "eslint-config-moneyforward",
   "version": "2.0.0",
   "description": "Money Forward's ESLint rules as an extensible shared config.",
+  "engines": {
+    "node": ">= 18.0.0"
+  },
   "scripts": {
     "lint": "eslint && prettier --check .",
     "lint:fix": "eslint --fix && prettier --write .",


### PR DESCRIPTION
## Summary

The following configuration file was exported and made available for reference by package users:

- [config/essentials](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/essentials.js)
- [config/jsdoc](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/jsdoc.js)
- [config/next](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/next.js)
- [config/node](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/node.js)
- [config/react](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/react.js)
- [config/storybook](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/storybook.js)
- [config/test/react](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/test/react.js)
- [config/typescript](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/configs/typescript.js)

Also, the package versions specified by `devDependencies` and `peerDependencies` have been adjusted to the v3 specifications.

## References

- [Design Overview of eslint-config-moneyforward 3 · moneyforward/eslint-config-moneyforward · Discussion #182](https://github.com/moneyforward/eslint-config-moneyforward/discussions/182#:~:text=presets%20at%20once.-,package.json,-%7B%0A%20%20%22name%22)