### PR TITLE
test: Reimplement the Unit Test "requires"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,10 @@
 module.exports = {
-  extends: ['./configs/essentials', './configs/node'].map(require.resolve),
+  extends: ['./configs/essentials', './configs/node', 'prettier'],
+
+  overrides: [
+    {
+      files: ['*.test.js'],
+      extends: ['./rules/jest'],
+    },
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,14 @@
       },
       "devDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-config-prettier": "^9.1.0",
         "jest": "^29.5.0",
         "prettier": "^2.8.7",
         "release-it": "^15.10.1",
         "typescript": ">= 4.2.4 || ^5.0.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
@@ -4747,6 +4751,18 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0 || ^8.2.0",
+    "eslint-config-prettier": "^9.1.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
     "release-it": "^15.10.1",

--- a/rules/index.js
+++ b/rules/index.js
@@ -1,4 +1,0 @@
-module.exports = {
-  extends: ['../configs/base'].map(require.resolve),
-  rules: {},
-};

--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -1,4 +1,0 @@
-module.exports = {
-  extends: ['../configs/prettier'].map(require.resolve),
-  rules: {},
-};

--- a/tests/requires.test.js
+++ b/tests/requires.test.js
@@ -1,26 +1,46 @@
-const fs = require('fs');
-const path = require('path');
-
-const readdirRecursively = (dir) => {
-  const dirents = fs.readdirSync(dir, { withFileTypes: true });
-  let files = [];
-  let dirs = [];
-  dirents.forEach((dirent) => {
-    if (dirent.isDirectory()) dirs.push(`${dir}/${dirent.name}`);
-    if (dirent.isFile()) files.push(`${dir}/${dirent.name}`);
-  });
-  dirs.forEach((dir) => {
-    files = readdirRecursively(dir, files);
-  });
-  return files;
-};
+/* eslint-disable import/no-dynamic-require */
+/* eslint-disable n/global-require */
+const { readdirSync } = require('fs');
+const { resolve, join } = require('path');
 
 test('parsable all configs', () => {
-  const files = readdirRecursively(path.resolve(`${__dirname}/../configs`));
-  files.forEach((file) => expect(() => require(file)).not.toThrow());
+  const dir = resolve(join(__dirname, '../configs'));
+
+  const files = readdirSync(dir, {
+    withFileTypes: true,
+  })
+    .map((dirnet) => extractFilePath(dirnet, dir))
+    .flat();
+
+  files.forEach((file) => {
+    expect(() => require(file)).not.toThrow();
+  });
 });
 
 test('parsable all rules', () => {
-  const files = readdirRecursively(path.resolve(`${__dirname}/../rules`));
-  files.forEach((file) => expect(() => require(file)).not.toThrow());
+  const dir = resolve(join(__dirname, '../rules'));
+
+  const files = readdirSync(dir, {
+    withFileTypes: true,
+  })
+    .map((dirnet) => extractFilePath(dirnet, dir))
+    .flat();
+
+  files.forEach((file) => {
+    expect(() => require(file)).not.toThrow();
+  });
 });
+
+function extractFilePath(dirent, dir) {
+  if (dirent.isFile()) {
+    return `${dir}/${dirent.name}`;
+  }
+
+  if (dirent.isDirectory()) {
+    return readdirSync(`${dir}/${dirent.name}`, {
+      withFileTypes: true,
+    })
+      .map((child) => extractFilePath(child, `${dir}/${dirent.name}`))
+      .flat();
+  }
+}


### PR DESCRIPTION
## Summary

The existing Unit Test [`/tests/requires.test.js`](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/tests/requires.test.js) wasn't working properly, so I reimplemented it.

This test collects the paths of JavaScript files under the specified directory and checks whether they can be loaded　correctly (they can be worked `require`).
However, when I ran the test, I found that it wasn't being collected at all. This was caused by  an incorrect implementation of the recursive function, and this was corrected to make it work correctly.

```js
// AS-IS
filePaths: [
  '/eslint-config-moneyforward/configs/test/react.js'
]

// TO-BE
filePaths: [
  '/eslint-config-moneyforward/configs/essentials.js',
  '/eslint-config-moneyforward/configs/jsdoc.js',
  '/eslint-config-moneyforward/configs/next.js',
  '/eslint-config-moneyforward/configs/node.js',
  '/eslint-config-moneyforward/configs/react.js',
  '/eslint-config-moneyforward/configs/storybook.js',
  '/eslint-config-moneyforward/configs/test/react.js',
  '/eslint-config-moneyforward/configs/typescript.js'
]
```

## Other

Introduced `eslint-config-prettier` to properly format test code with ESLint and Prettier.

## References

- #209 