### PR TITLE
fix: Allow to omit importing some functions for test files written in TypeScript

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -82,9 +82,9 @@ module.exports = {
           'spec/**', // mocha, rspec-like pattern
           '**/__tests__/**', // jest pattern
           '**/__mocks__/**', // jest pattern
-          'test.{js,jsx}', // repos with a single test file
-          'test-*.{js,jsx}', // repos with multiple top-level test files
-          '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
+          'test.{js,jsx,ts,tsx}', // repos with a single test file
+          'test-*.{js,jsx,ts,tsx}', // repos with multiple top-level test files
+          '**/*{.,_}{test,spec}.{js,jsx,ts,tsx}', // tests where the extension or filename suffix denotes that it is a test
           '**/jest.config.js', // jest config
           '**/jest.setup.js', // jest setup
           '**/vue.config.js', // vue-cli config


### PR DESCRIPTION
## Summary

Test files written in TypeScript aren't subject to the [`import/no-extraneous-dependencies`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) rule.

In test code, imports of functions such as `describe`, `test`, and `it` are generally omitted. This rule was already applied to test files written VanillaJS, but it was added because TypeScript files were missing.

## References

- #213