### PR TITLE
ci: Fix the method of specifying the Node.js version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,26 @@
 name: test
-on: pull_request
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
 jobs:
   test:
     strategy:
       matrix:
-        node: [14.x, 16.x, 18.x]
         eslint: [7, 8]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ./.node-version
+
       - name: Use ESLint ${{ matrix.eslint }}
         run: npm install eslint@${{ matrix.eslint }}
+
       - run: |
           npm install --silent
           npm run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
## Summary

Unify the Node.js version specified for running tests in CI to the one specified in `.node-version` file.

Until now, `v14`, `v16` and `v18` were specified. However, since we're currently developing according to the version described in `.node-version` file, it should be sufficient if the test succeeds with this version.

## Others

The format of the `CHANGELOG.md` is invalid for Prettier, but since this file is generated automatically by CD ( `semantic-release` ), it is appropriate not to have Prettier check it.