### PR TITLE
feat: Update Node.js version requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": ">= 4.2.4 || ^5.0.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 18.18.0 || >= 20.0.0"
       },
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "./typescript": "./configs/typescript.js"
   },
   "engines": {
-    "node": ">= 18.0.0"
+    "node": ">= 18.18.0 || >= 20.0.0"
   },
   "scripts": {
     "lint": "eslint && prettier --check .",


### PR DESCRIPTION
## BREAKING CHANGE:

Update Node.js engine requirement to `>= 18.18.0 || >= 20.0.0`. This means we are dropping support for Node 18 versions prior to `18.18.0`.

## Context

To update `@typescript-eslint` from the current `v6` to `v7`, we need to increase the minimum Node.js version to `v18.18.0`.

## References

- #276 
- [typescript-eslint/CHANGELOG.md at main · typescript-eslint/typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/blob/main/CHANGELOG.md#700-2024-02-12)
- [feat: bump ESLint, NodeJS, and TS minimum version requirements by bradzacher · Pull Request #8377 · typescript-eslint/typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/pull/8377)