### PR TITLE
feat: Update ESLint version requirement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        eslint: [7, 8]
+        eslint: [8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
-        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "jest": "^29.5.0",
         "prettier": "^2.8.7",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
-    "eslint": "^7.32.0 || ^8.2.0",
+    "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
@@ -59,7 +59,7 @@
     "typescript": ">= 4.2.4 || ^5.0.0"
   },
   "peerDependencies": {
-    "eslint": "^7.32.0 || ^8.2.0",
+    "eslint": "^8.56.0",
     "typescript": ">= 4.2.4 || ^5.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## BREAKING CHANGE:

Update the ESLint peer dependency requirement to `^8.56.0`. This means we are dropping support for ESLint 7, and we are also dropping support ESLint 8 versions prior to `8.56.0`.

## Context

- To update `@typescript-eslint` from the current `v6` to `v7`, we need to increase the minimum Node.js version to `v18.18.0`.
- To update `eslint-plugin-n` from the current `v16` to `v17`, we need to increase the minimum ESLint version to `v8`.

## References

- #276 
- [typescript-eslint/CHANGELOG.md at main · typescript-eslint/typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/blob/main/CHANGELOG.md#700-2024-02-12)
- [feat: bump ESLint, NodeJS, and TS minimum version requirements by bradzacher · Pull Request #8377 · typescript-eslint/typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/pull/8377)