### PR TITLE
fix: Allow import of devDependency modules in Storybook files

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -97,6 +97,8 @@ module.exports = {
           '**/karma.conf.js', // karma config
           '**/.eslintrc.js', // eslint config
           '**/eslint-rules/**',
+          '**/.storybook/**', // storybook config
+          '**/*.stories.{js,jsx,ts,tsx}', // storybook stories
         ],
         optionalDependencies: false,
       },

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -98,7 +98,7 @@ module.exports = {
           '**/.eslintrc.js', // eslint config
           '**/eslint-rules/**',
           '**/.storybook/**', // storybook config
-          '**/*.stories.{js,jsx,ts,tsx}', // storybook stories
+          '**/*.stories.{js,jsx,ts,tsx,mdx}', // storybook stories
         ],
         optionalDependencies: false,
       },


### PR DESCRIPTION
## Summary

Storybook related files need to import devDependency modules. Therefore, we need to modify ESLint's import rule to allow this.

## References

- #267 
- [eslint-plugin-import/docs/rules/no-extraneous-dependencies.md at main · import-js/eslint-plugin-import](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md)