### PR TITLE
ci: Reimplement release workflow with GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
+
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,6 +10,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -27,5 +33,5 @@ jobs:
       - name: Release
         run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow was reimplemented from the existing design using GitHub Secrets to a design using GitHub App. The GitHub App is already installed in this repository, and the access token issued from it is used to run the release workflow. This should make it possible to use Branch Protection and semantic-release together.

Also, Implemented a release workflow in the GitHub Action workflow, with the trigger being [workflow_dispatch](https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch). This means that it is not automatically executed every time a change is merged into the default branch, but rather at a time of the developer's choosing.

## References

- [CD 構築 - semantic-release が Protected Branch に対し force-push できるようにする · Issue #148 · moneyforward/frontend-forward](https://github.com/moneyforward/frontend-forward/issues/148)
- [/ADRs/2024-05-16-operation-of-semantic-release-for-branch-protection-rules.md](https://github.com/moneyforward/frontend-forward/blob/main/docs/ADRs/2024-05-16-operation-of-semantic-release-for-branch-protection-rules.md)
- [/ADRs/2024-05-17-release-workflow-with-semantic-release.md](https://github.com/moneyforward/frontend-forward/blob/main/docs/ADRs/2024-05-17-release-workflow-with-semantic-release.md)