### PR TITLE
fix: Resolve the problem of incorrect recognition of alias path by TypeScript's Compiler Options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@typescript-eslint/eslint-plugin": "^7.10.0",
         "@typescript-eslint/parser": "^7.10.0",
         "confusing-browser-globals": "^1.0.11",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^28.5.0",
         "eslint-plugin-jest-dom": "^5.1.0",
@@ -4888,6 +4889,30 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "confusing-browser-globals": "^1.0.11",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^28.5.0",
     "eslint-plugin-jest-dom": "^5.1.0",

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -20,6 +20,9 @@ module.exports = {
       node: {
         extensions: ['.js', '.mjs', '.json'],
       },
+      // Resolve the problem of incorrect recognition of alias paths by TypeScript compiler options.
+      // https://github.com/import-js/eslint-plugin-import/issues/1485#issuecomment-535351922
+      typescript: {},
     },
     'import/extensions': ['.js', '.mjs', '.jsx'],
     'import/core-modules': [],


### PR DESCRIPTION
## Summary

Resolved the problem of incorrect recognition of alias path by TypeScript's Compiler Options.

## References

- #281 
- https://github.com/import-js/eslint-plugin-import/issues/1485#issuecomment-535351922
- [eslint-import-resolver-typescript - npm](https://www.npmjs.com/package/eslint-import-resolver-typescript)