### PR TITLE
fix: `import/namespace` error

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -18,7 +18,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.js', '.mjs', '.json'],
+        extensions: ['.js', '.mjs', '.json', 'ts', 'mts'],
       },
     },
     'import/extensions': ['.js', '.mjs', '.jsx'],
@@ -27,6 +27,11 @@ module.exports = {
       'node_modules',
       '\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$',
     ],
+    // TODO: Remove this once eslint-plugin-import supports Flat Config completely.
+    // https://github.com/import-js/eslint-plugin-import/issues/2556#issuecomment-1419518561
+    'import/parsers': {
+      espree: ['.js', '.mjs', '.jsx', 'ts', 'mts', 'tsx'],
+    },
   },
 
   rules: {


### PR DESCRIPTION
## Summary 

Flat Config support for eslint-plugin-import is not yet complete, which may cause import/namespace errors. A fix has been added to resolve this issue.

## References

- #284 
- https://github.com/import-js/eslint-plugin-import/issues/2556#issuecomment-1419518561