### PR TITLE
feat: Remove deprecated rule settings

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -64,10 +64,6 @@ module.exports = {
     // https://eslint.org/docs/rules/dot-notation
     'dot-notation': ['error', { allowKeywords: true }],
 
-    // enforces consistent newlines before or after dots
-    // https://eslint.org/docs/rules/dot-location
-    'dot-location': ['error', 'property'],
-
     // require the use of === and !==
     // https://eslint.org/docs/rules/eqeqeq
     eqeqeq: ['error', 'always', { null: 'ignore' }],
@@ -151,17 +147,9 @@ module.exports = {
     // https://eslint.org/docs/rules/no-fallthrough
     'no-fallthrough': ['error'],
 
-    // disallow the use of leading or trailing decimal points in numeric literals
-    // https://eslint.org/docs/rules/no-floating-decimal
-    'no-floating-decimal': ['error'],
-
     // disallow reassignments of native objects or read-only globals
     // https://eslint.org/docs/rules/no-global-assign
     'no-global-assign': ['error', { exceptions: [] }],
-
-    // deprecated in favor of no-global-assign
-    // https://eslint.org/docs/rules/no-native-reassign
-    'no-native-reassign': ['off'],
 
     // disallow implicit type conversions
     // https://eslint.org/docs/rules/no-implicit-coercion
@@ -212,15 +200,6 @@ module.exports = {
         ignoreArrayIndexes: true,
         enforceConst: true,
         detectObjects: false,
-      },
-    ],
-
-    // disallow use of multiple spaces
-    // https://eslint.org/docs/rules/no-multi-spaces
-    'no-multi-spaces': [
-      'error',
-      {
-        ignoreEOLComments: false,
       },
     ],
 
@@ -342,10 +321,6 @@ module.exports = {
     // https://eslint.org/docs/rules/no-return-assign
     'no-return-assign': ['error', 'always'],
 
-    // disallow redundant `return await`
-    // https://eslint.org/docs/rules/no-return-await
-    'no-return-await': ['error'],
-
     // disallow use of `javascript:` urls.
     // https://eslint.org/docs/rules/no-script-url
     'no-script-url': ['error'],
@@ -460,10 +435,6 @@ module.exports = {
     // requires to declare all vars on top of their containing scope
     // https://eslint.org/docs/rules/vars-on-top
     'vars-on-top': ['error'],
-
-    // require immediate function invocation to be wrapped in parentheses
-    // https://eslint.org/docs/rules/wrap-iife.html
-    'wrap-iife': ['error', 'outside', { functionPrototypeMethods: false }],
 
     // require or disallow Yoda conditions
     // https://eslint.org/docs/rules/yoda

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -84,23 +84,6 @@ module.exports = {
     // https://eslint.org/docs/rules/no-extra-boolean-cast
     'no-extra-boolean-cast': ['error'],
 
-    // disallow unnecessary parentheses
-    // https://eslint.org/docs/rules/no-extra-parens
-    'no-extra-parens': [
-      'off',
-      'all',
-      {
-        conditionalAssign: true,
-        nestedBinaryExpressions: false,
-        returnAssign: false,
-        ignoreJSX: 'all', // delegate to eslint-plugin-react
-        enforceForArrowConditionals: false,
-      },
-    ],
-
-    // disallow unnecessary semicolons
-    'no-extra-semi': ['error'],
-
     // disallow overwriting functions written as function declarations
     'no-func-assign': ['error'],
 

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -25,29 +25,12 @@ module.exports = {
     // https://eslint.org/docs/rules/arrow-parens
     'arrow-parens': ['error', 'always'],
 
-    // require space before/after arrow function's arrow
-    // https://eslint.org/docs/rules/arrow-spacing
-    'arrow-spacing': ['error', { before: true, after: true }],
-
     // verify super() callings in constructors
     'constructor-super': 'error',
-
-    // enforce the spacing around the * in generator functions
-    // https://eslint.org/docs/rules/generator-star-spacing
-    'generator-star-spacing': ['error', { before: false, after: true }],
 
     // disallow modifying variables of class declarations
     // https://eslint.org/docs/rules/no-class-assign
     'no-class-assign': 'error',
-
-    // disallow arrow functions where they could be confused with comparisons
-    // https://eslint.org/docs/rules/no-confusing-arrow
-    'no-confusing-arrow': [
-      'error',
-      {
-        allowParens: true,
-      },
-    ],
 
     // disallow modifying variables that are declared using const
     'no-const-assign': ['error'],
@@ -60,10 +43,6 @@ module.exports = {
     // https://eslint.org/docs/rules/no-duplicate-imports
     // replaced by https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
     'no-duplicate-imports': ['off'],
-
-    // disallow symbol constructor
-    // https://eslint.org/docs/rules/no-new-symbol
-    'no-new-symbol': ['error'],
 
     // Disallow specified names in exports
     // https://eslint.org/docs/rules/no-restricted-exports
@@ -170,10 +149,6 @@ module.exports = {
     // https://eslint.org/docs/rules/prefer-numeric-literals
     'prefer-numeric-literals': ['error'],
 
-    // suggest using Reflect methods where applicable
-    // https://eslint.org/docs/rules/prefer-reflect
-    'prefer-reflect': ['off'],
-
     // use rest parameters instead of arguments
     // https://eslint.org/docs/rules/prefer-rest-params
     'prefer-rest-params': ['error'],
@@ -185,10 +160,6 @@ module.exports = {
     // suggest using template literals instead of string concatenation
     // https://eslint.org/docs/rules/prefer-template
     'prefer-template': ['error'],
-
-    // enforce spacing between object rest-spread
-    // https://eslint.org/docs/rules/rest-spread-spacing
-    'rest-spread-spacing': ['error', 'never'],
 
     // import sorting
     // https://eslint.org/docs/rules/sort-imports
@@ -205,13 +176,5 @@ module.exports = {
     // require a Symbol description
     // https://eslint.org/docs/rules/symbol-description
     'symbol-description': ['error'],
-
-    // enforce usage of spacing in template strings
-    // https://eslint.org/docs/rules/template-curly-spacing
-    'template-curly-spacing': ['error'],
-
-    // enforce spacing around the * in yield* expressions
-    // https://eslint.org/docs/rules/yield-star-spacing
-    'yield-star-spacing': ['error', 'after'],
   },
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -18,22 +18,6 @@ module.exports = {
     // TODO: enable? semver-major
     'array-bracket-newline': ['off', 'consistent'], // object option alternative: { multiline: true, minItems: 3 }
 
-    // enforce line breaks between array elements
-    // https://eslint.org/docs/rules/array-element-newline
-    // TODO: enable? semver-major
-    'array-element-newline': ['off', { multiline: true, minItems: 3 }],
-
-    // enforce spacing inside array brackets
-    'array-bracket-spacing': ['error', 'never'],
-
-    // enforce spacing inside single-line blocks
-    // https://eslint.org/docs/rules/block-spacing
-    'block-spacing': ['error', 'always'],
-
-    // enforce one true brace style
-    // https://eslint.org/docs/rules/brace-style
-    'brace-style': ['error', '1tbs', { allowSingleLine: true }],
-
     // require camel case names
     // https://eslint.org/docs/rules/camelcase
     camelcase: ['error', { properties: 'never', ignoreDestructuring: false }],
@@ -57,63 +41,9 @@ module.exports = {
       },
     ],
 
-    // require trailing commas in multiline object literals
-    // https://eslint.org/docs/rules/comma-dangle
-    'comma-dangle': [
-      'error',
-      {
-        arrays: 'always-multiline',
-        objects: 'always-multiline',
-        imports: 'always-multiline',
-        exports: 'always-multiline',
-        functions: 'always-multiline',
-      },
-    ],
-
-    // enforce spacing before and after comma
-    // https://eslint.org/docs/rules/comma-spacing
-    'comma-spacing': ['error', { before: false, after: true }],
-
-    // enforce one true comma style
-    // https://eslint.org/docs/rules/comma-style
-    'comma-style': [
-      'error',
-      'last',
-      {
-        exceptions: {
-          ArrayExpression: false,
-          ArrayPattern: false,
-          ArrowFunctionExpression: false,
-          CallExpression: false,
-          FunctionDeclaration: false,
-          FunctionExpression: false,
-          ImportDeclaration: false,
-          ObjectExpression: false,
-          ObjectPattern: false,
-          VariableDeclaration: false,
-          NewExpression: false,
-        },
-      },
-    ],
-
-    // disallow padding inside computed properties
-    // https://eslint.org/docs/rules/computed-property-spacing
-    'computed-property-spacing': ['error', 'never'],
-
     // enforces consistent naming when capturing the current execution context
     // https://eslint.org/docs/rules/consistent-this
     'consistent-this': ['off'],
-
-    // enforce newline at the end of file, with no multiple empty lines
-    // https://eslint.org/docs/rules/eol-last
-    'eol-last': ['error', 'always'],
-
-    // https://eslint.org/docs/rules/function-call-argument-newline
-    'function-call-argument-newline': ['error', 'consistent'],
-
-    // enforce spacing between functions and their invocations
-    // https://eslint.org/docs/rules/func-call-spacing
-    'func-call-spacing': ['error', 'never'],
 
     // requires function names to match the name of the variable or property to which they are
     // assigned
@@ -136,10 +66,6 @@ module.exports = {
     // TODO: enable
     'func-style': ['off', 'expression'],
 
-    // require line breaks inside function parentheses if there are line breaks between parameters
-    // https://eslint.org/docs/rules/function-paren-newline
-    'function-paren-newline': ['error', 'multiline-arguments'],
-
     // disallow specified identifiers
     // https://eslint.org/docs/rules/id-denylist
     'id-denylist': ['off'],
@@ -152,111 +78,6 @@ module.exports = {
     // require identifiers to match the provided regular expression
     // https://eslint.org/docs/rules/id-match
     'id-match': ['off'],
-
-    // Enforce the location of arrow function bodies with implicit returns
-    // https://eslint.org/docs/rules/implicit-arrow-linebreak
-    'implicit-arrow-linebreak': ['error', 'beside'],
-
-    // this option sets a specific tab width for your code
-    // https://eslint.org/docs/rules/indent
-    indent: [
-      'error',
-      2,
-      {
-        SwitchCase: 1,
-        VariableDeclarator: 1,
-        outerIIFEBody: 1,
-        // MemberExpression: null,
-        FunctionDeclaration: {
-          parameters: 1,
-          body: 1,
-        },
-        FunctionExpression: {
-          parameters: 1,
-          body: 1,
-        },
-        CallExpression: {
-          arguments: 1,
-        },
-        ArrayExpression: 1,
-        ObjectExpression: 1,
-        ImportDeclaration: 1,
-        flatTernaryExpressions: false,
-        // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
-        ignoredNodes: [
-          'JSXElement',
-          'JSXElement > *',
-          'JSXAttribute',
-          'JSXIdentifier',
-          'JSXNamespacedName',
-          'JSXMemberExpression',
-          'JSXSpreadAttribute',
-          'JSXExpressionContainer',
-          'JSXOpeningElement',
-          'JSXClosingElement',
-          'JSXFragment',
-          'JSXOpeningFragment',
-          'JSXClosingFragment',
-          'JSXText',
-          'JSXEmptyExpression',
-          'JSXSpreadChild',
-        ],
-        ignoreComments: false,
-      },
-    ],
-
-    // specify whether double or single quotes should be used in JSX attributes
-    // https://eslint.org/docs/rules/jsx-quotes
-    'jsx-quotes': ['off', 'prefer-double'],
-
-    // enforces spacing between keys and values in object literal properties
-    // https://eslint.org/docs/rules/key-spacing
-    'key-spacing': ['error', { beforeColon: false, afterColon: true }],
-
-    // require a space before & after certain keywords
-    // https://eslint.org/docs/rules/keyword-spacing
-    'keyword-spacing': [
-      'error',
-      {
-        before: true,
-        after: true,
-        overrides: {
-          return: { after: true },
-          throw: { after: true },
-          case: { after: true },
-        },
-      },
-    ],
-
-    // enforce position of line comments
-    // https://eslint.org/docs/rules/line-comment-position
-    // TODO: enable?
-    'line-comment-position': [
-      'off',
-      {
-        position: 'above',
-        ignorePattern: '',
-        applyDefaultPatterns: true,
-      },
-    ],
-
-    // disallow mixed 'LF' and 'CRLF' as linebreaks
-    // https://eslint.org/docs/rules/linebreak-style
-    'linebreak-style': ['error', 'unix'],
-
-    // enforces empty lines around comments
-    // https://eslint.org/docs/rules/lines-around-comment
-    'lines-around-comment': ['off'],
-
-    // require or disallow newlines around directives
-    // https://eslint.org/docs/rules/lines-around-directive
-    'lines-around-directive': [
-      'error',
-      {
-        before: 'always',
-        after: 'always',
-      },
-    ],
 
     // Require or disallow logical assignment logical operator shorthand
     // https://eslint.org/docs/latest/rules/logical-assignment-operators
@@ -272,21 +93,6 @@ module.exports = {
     // specify the maximum depth that blocks can be nested
     // https://eslint.org/docs/latest/rules/max-depth
     'max-depth': ['off', 4],
-
-    // specify the maximum length of a line in your program
-    // https://eslint.org/docs/rules/max-len
-    'max-len': [
-      'error',
-      100,
-      2,
-      {
-        ignoreUrls: true,
-        ignoreComments: false,
-        ignoreRegExpLiterals: true,
-        ignoreStrings: true,
-        ignoreTemplateLiterals: true,
-      },
-    ],
 
     // specify the max number of lines in a file
     // https://eslint.org/docs/rules/max-lines
@@ -327,15 +133,6 @@ module.exports = {
     // https://eslint.org/docs/rules/max-statements-per-line
     'max-statements-per-line': ['off', { max: 1 }],
 
-    // enforce a particular style for multiline comments
-    // https://eslint.org/docs/rules/multiline-comment-style
-    'multiline-comment-style': ['off', 'starred-block'],
-
-    // require multiline ternary
-    // https://eslint.org/docs/rules/multiline-ternary
-    // TODO: enable?
-    'multiline-ternary': ['off', 'never'],
-
     // require a capital letter for constructors
     // https://eslint.org/docs/rules/new-cap
     'new-cap': [
@@ -351,22 +148,6 @@ module.exports = {
         ],
       },
     ],
-
-    // disallow the omission of parentheses when invoking a constructor with no arguments
-    // https://eslint.org/docs/rules/new-parens
-    'new-parens': ['error'],
-
-    // allow/disallow an empty newline after var statement
-    // https://eslint.org/docs/rules/newline-after-var
-    'newline-after-var': ['off'],
-
-    // https://eslint.org/docs/rules/newline-before-return
-    'newline-before-return': ['off'],
-
-    // enforces new line after each method call in the chain to make it
-    // more readable and easy to maintain
-    // https://eslint.org/docs/rules/newline-per-chained-call
-    'newline-per-chained-call': ['error', { ignoreChainWithDepth: 4 }],
 
     // disallow use of the Array constructor
     // https://eslint.org/docs/rules/no-array-constructor
@@ -388,39 +169,9 @@ module.exports = {
     // https://eslint.org/docs/rules/no-lonely-if
     'no-lonely-if': ['error'],
 
-    // disallow un-paren'd mixes of different operators
-    // https://eslint.org/docs/rules/no-mixed-operators
-    'no-mixed-operators': [
-      'error',
-      {
-        // the list of arithmetic groups disallows mixing `%` and `**`
-        // with other arithmetic operators.
-        groups: [
-          ['%', '**'],
-          ['%', '+'],
-          ['%', '-'],
-          ['%', '*'],
-          ['%', '/'],
-          ['/', '*'],
-          ['&', '|', '<<', '>>', '>>>'],
-          ['==', '!=', '===', '!=='],
-          ['&&', '||'],
-        ],
-        allowSamePrecedence: false,
-      },
-    ],
-
-    // disallow mixed spaces and tabs for indentation
-    // https://eslint.org/docs/rules/no-mixed-spaces-and-tabs
-    'no-mixed-spaces-and-tabs': ['error'],
-
     // disallow use of chained assignment expressions
     // https://eslint.org/docs/rules/no-multi-assign
     'no-multi-assign': ['error'],
-
-    // disallow multiple empty lines, only one newline at the end, and no new lines at the beginning
-    // https://eslint.org/docs/rules/no-multiple-empty-lines
-    'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
 
     // disallow negated conditions
     // https://eslint.org/docs/rules/no-negated-condition
@@ -429,10 +180,6 @@ module.exports = {
     // disallow nested ternary expressions
     // https://eslint.org/docs/rules/no-nested-ternary
     'no-nested-ternary': ['off'],
-
-    // disallow use of the Object constructor
-    // https://eslint.org/docs/rules/no-new-object
-    'no-new-object': ['error'],
 
     // disallow use of unary operators, ++ and --
     // https://eslint.org/docs/rules/no-plusplus
@@ -464,23 +211,9 @@ module.exports = {
       },
     ],
 
-    // disallow tab characters entirely
-    // https://eslint.org/docs/rules/no-tabs
-    'no-tabs': ['error'],
-
     // disallow the use of ternary operators
     // https://eslint.org/docs/rules/no-ternary
     'no-ternary': ['off'],
-
-    // disallow trailing whitespace at the end of lines
-    // https://eslint.org/docs/rules/no-trailing-spaces
-    'no-trailing-spaces': [
-      'error',
-      {
-        skipBlankLines: false,
-        ignoreComments: false,
-      },
-    ],
 
     // disallow dangling underscores in identifiers
     // https://eslint.org/docs/rules/no-underscore-dangle
@@ -499,84 +232,13 @@ module.exports = {
     // https://eslint.org/docs/rules/no-unneeded-ternary
     'no-unneeded-ternary': ['error', { defaultAssignment: false }],
 
-    // disallow whitespace before properties
-    // https://eslint.org/docs/rules/no-whitespace-before-property
-    'no-whitespace-before-property': ['error'],
-
-    // enforce the location of single-line statements
-    // https://eslint.org/docs/rules/nonblock-statement-body-position
-    'nonblock-statement-body-position': ['error', 'beside', { overrides: {} }],
-
-    // require padding inside curly braces
-    // https://eslint.org/docs/rules/object-curly-spacing
-    'object-curly-spacing': ['error', 'always'],
-
-    // enforce line breaks between braces
-    // https://eslint.org/docs/rules/object-curly-newline
-    'object-curly-newline': [
-      'error',
-      {
-        ObjectExpression: {
-          minProperties: 4,
-          multiline: true,
-          consistent: true,
-        },
-        ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
-        ImportDeclaration: {
-          minProperties: 4,
-          multiline: true,
-          consistent: true,
-        },
-        ExportDeclaration: {
-          minProperties: 4,
-          multiline: true,
-          consistent: true,
-        },
-      },
-    ],
-
-    // enforce "same line" or "multiple line" on object properties.
-    // https://eslint.org/docs/rules/object-property-newline
-    'object-property-newline': [
-      'error',
-      {
-        allowAllPropertiesOnSameLine: true,
-      },
-    ],
-
     // allow just one var statement per function
     // https://eslint.org/docs/rules/one-var
     'one-var': ['error', 'never'],
 
-    // require a newline around variable declaration
-    // https://eslint.org/docs/rules/one-var-declaration-per-line
-    'one-var-declaration-per-line': ['error', 'always'],
-
     // require assignment operator shorthand where possible or prohibit it entirely
     // https://eslint.org/docs/rules/operator-assignment
     'operator-assignment': ['error', 'always'],
-
-    // Requires operator at the beginning of the line in multiline statements
-    // https://eslint.org/docs/rules/operator-linebreak
-    'operator-linebreak': ['error', 'before', { overrides: { '=': 'none' } }],
-
-    // disallow padding within blocks
-    // https://eslint.org/docs/rules/padded-blocks
-    'padded-blocks': [
-      'error',
-      {
-        blocks: 'never',
-        classes: 'never',
-        switches: 'never',
-      },
-      {
-        allowSingleLineBlocks: true,
-      },
-    ],
-
-    // Require or disallow padding lines between statements
-    // https://eslint.org/docs/rules/padding-line-between-statements
-    'padding-line-between-statements': ['off'],
 
     // Disallow the use of Math.pow in favor of the ** operator
     // https://eslint.org/docs/rules/prefer-exponentiation-operator
@@ -586,33 +248,9 @@ module.exports = {
     // https://eslint.org/docs/rules/prefer-object-spread
     'prefer-object-spread': ['error'],
 
-    // require quotes around object literal property names
-    // https://eslint.org/docs/rules/quote-props.html
-    'quote-props': [
-      'error',
-      'as-needed',
-      { keywords: false, unnecessary: true, numbers: false },
-    ],
-
-    // specify whether double or single quotes should be used
-    // https://eslint.org/docs/rules/quotes
-    quotes: ['error', 'single', { avoidEscape: true }],
-
     // do not require jsdoc
     // https://eslint.org/docs/rules/require-jsdoc
     'require-jsdoc': ['off'],
-
-    // require or disallow use of semicolons instead of ASI
-    // https://eslint.org/docs/rules/semi
-    semi: ['error', 'always'],
-
-    // enforce spacing before and after semicolons
-    // https://eslint.org/docs/rules/semi-spacing
-    'semi-spacing': ['error', { before: false, after: true }],
-
-    // Enforce location of semicolons
-    // https://eslint.org/docs/rules/semi-style
-    'semi-style': ['error', 'last'],
 
     // requires object keys to be sorted
     // https://eslint.org/docs/rules/sort-keys
@@ -622,72 +260,8 @@ module.exports = {
     // https://eslint.org/docs/rules/sort-vars
     'sort-vars': ['off'],
 
-    // require or disallow space before blocks
-    // https://eslint.org/docs/rules/space-before-blocks
-    'space-before-blocks': ['error'],
-
-    // require or disallow space before function opening parenthesis
-    // https://eslint.org/docs/rules/space-before-function-paren
-    'space-before-function-paren': [
-      'error',
-      {
-        anonymous: 'always',
-        named: 'never',
-        asyncArrow: 'always',
-      },
-    ],
-
-    // require or disallow spaces inside parentheses
-    // https://eslint.org/docs/rules/space-in-parens
-    'space-in-parens': ['error', 'never'],
-
-    // require spaces around operators
-    // https://eslint.org/docs/rules/space-infix-ops
-    'space-infix-ops': ['error'],
-
-    // Require or disallow spaces before/after unary operators
-    // https://eslint.org/docs/rules/space-unary-ops
-    'space-unary-ops': [
-      'error',
-      {
-        words: true,
-        nonwords: false,
-        overrides: {},
-      },
-    ],
-
-    // require or disallow a space immediately following the // or /* in a comment
-    // https://eslint.org/docs/rules/spaced-comment
-    'spaced-comment': [
-      'error',
-      'always',
-      {
-        line: {
-          exceptions: ['-', '+'],
-          markers: ['=', '!', '/'], // space here to support sprockets directives, slash for TS /// comments
-        },
-        block: {
-          exceptions: ['-', '+'],
-          markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
-          balanced: true,
-        },
-      },
-    ],
-
-    // Enforce spacing around colons of switch statements
-    // https://eslint.org/docs/rules/switch-colon-spacing
-    'switch-colon-spacing': ['error', { after: true, before: false }],
-
-    // Require or disallow spacing between template tags and their literals
-    // https://eslint.org/docs/rules/template-tag-spacing
-    'template-tag-spacing': ['error', 'never'],
-
     // require or disallow the Unicode Byte Order Mark
     // https://eslint.org/docs/rules/unicode-bom
     'unicode-bom': ['error', 'never'],
-
-    // require regex literals to be wrapped in parentheses
-    // https://eslint.org/docs/rules/wrap-regex
-    'wrap-regex': ['off'],
   },
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -19,10 +19,6 @@ module.exports = {
     // https://eslint.org/docs/rules/init-declarations
     'init-declarations': 'off',
 
-    // disallow the catch clause parameter name being the same as a variable in the outer scope
-    // https://eslint.org/docs/rules/no-catch-shadow
-    'no-catch-shadow': 'off',
-
     // disallow deletion of variables
     // https://eslint.org/docs/rules/no-delete-var
     'no-delete-var': 'error',


### PR DESCRIPTION
## Summary

Remove rule settings that are deprecated as of ESLint v8.56.0 or lower.

## References

- #282 
- [Rules Reference - ESLint - Pluggable JavaScript Linter](https://eslint.org/docs/latest/rules/#deprecated)