### PR TITLE
chore: Specify files to upload to npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "engines": {
     "node": ">= 18.18.0 || >= 20.0.0"
   },
+  "files": [
+    "configs",
+    "rules"
+  ],
   "scripts": {
     "lint": "eslint && prettier --check .",
     "lint:fix": "eslint --fix && prettier --write .",


### PR DESCRIPTION
## Summary

Specified only those files (or folders) to upload to npmjs that users really need.

Currently, all source code in the repository has been uploaded to npmjs. Since it's a small repository, there is no impact on the installation load, but it is preferable to exclude files that are irrelevant to users, such as CI/CD-related files.

## References

- #283