### PR TITLE
fix: Specify `jest` as a Peer Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.56.0",
+        "jest": "*",
         "typescript": "^4.7.5 || ^5.0.0"
       },
       "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
         "typescript": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -65,9 +65,13 @@
   },
   "peerDependencies": {
     "eslint": "^8.56.0",
+    "jest": "*",
     "typescript": "^4.7.5 || ^5.0.0"
   },
   "peerDependenciesMeta": {
+    "jest": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }


### PR DESCRIPTION
## Summary

Add `jest` to the Peer Dependency list to prompt `eslint-config-moneyforward` users to install Jest.

## Context

`eslint-plugin-jest` is intended for use in environments where Jest is installed.
Therefore, it is advisable to check if Jest is installed when installing `eslint-config-moneyforward`.

## References

- https://github.com/jest-community/eslint-plugin-jest/blob/main/package.json#L111