### PR TITLE
docs: Add missing import config for Next.js to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We also provide various other rule sets that you can configure to suit your proj
 import {
   essentials,
   jsdoc,
+  next,
   node,
   react,
   storybook,


### PR DESCRIPTION
## Summary

I found the import config for Next.js was missing in an example of README when I integrated this config into my project.

I added `next` to the import statement of the example to the same as the order of export default.

## References

- N/A