### PR TITLE
docs: Fix comments for react/jsx-sort-props

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -96,7 +96,13 @@ module.exports = {
     // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
     'react/jsx-pascal-case': ['error', { allowAllCaps: true }],
 
-    // Enforce props alphabetical sorting
+    // Enforce props sorting
+    // The order of props is as follows:
+    //   1. React reserved props: e.g. key, ref
+    //   2. Shorthand props: e.g. disabled
+    //   3. Others
+    //   4. Callbacks e.g. onClick
+    // The props will no be sorted alphabetically.
     // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
     'react/jsx-sort-props': [
       'error',


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

The comments in [react/jsx-sort-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md) were wrong with the actual behavior.

**The behavior written in the comments:**
Props are sorted alphabetically.

**The actual behavior:**
Props are sorted in order of meaning, not alphabetically.
1. React reserved props: e.g. key, ref
2. Shorthand props: e.g. disabled
3. Others 
4. Callbacks e.g. onClick

## Linked PR / Issues

<!-- Fixes # (issue) -->

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->
