### PR TITLE
fix: TypeScript `import` and `export` parsing

### DIFF
--- a/configs/flat/typescript.mjs
+++ b/configs/flat/typescript.mjs
@@ -26,6 +26,13 @@ export default [
       },
     },
 
+    settings: {
+      // https://github.com/import-js/eslint-plugin-import?tab=readme-ov-file#importparsers
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.tsx', '.cts', '.mts'],
+      },
+    },
+
     ...typescriptRuleSet,
   },
 ];

--- a/tests/snapshot-test/flat/next/__snapshots__/snapshot.test.js.snap
+++ b/tests/snapshot-test/flat/next/__snapshots__/snapshot.test.js.snap
@@ -2829,6 +2829,12 @@ exports[`should match ESLint Flat Configuration snapshot: next 1`] = `
       "\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$",
     ],
     "import/parsers": {
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+      ],
       "espree": [
         ".js",
         "cjs",

--- a/tests/snapshot-test/flat/react/__snapshots__/snapshot.test.js.snap
+++ b/tests/snapshot-test/flat/react/__snapshots__/snapshot.test.js.snap
@@ -2766,6 +2766,12 @@ exports[`should match ESLint Configuration snapshot: react 1`] = `
       "\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$",
     ],
     "import/parsers": {
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+      ],
       "espree": [
         ".js",
         "cjs",

--- a/tests/snapshot-test/flat/storybook/__snapshots__/snapshot.test.js.snap
+++ b/tests/snapshot-test/flat/storybook/__snapshots__/snapshot.test.js.snap
@@ -2568,6 +2568,12 @@ exports[`should match ESLint Flat Configuration snapshot: storybook 1`] = `
       "\\.(coffee|scss|css|less|hbs|svg|json|jpg|jpeg|png|webp)$",
     ],
     "import/parsers": {
+      "@typescript-eslint/parser": [
+        ".ts",
+        ".tsx",
+        ".cts",
+        ".mts",
+      ],
       "espree": [
         ".js",
         "cjs",


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

The parsing settings for `import` and `export` in TypeScript were insufficient, so this bug will be fixed. Without this setting, `import * from` and `export * from` cannot be parsed properly.

## Linked PR / Issues

<!-- Fixes # (issue) -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->

- [import-js/eslint-plugin-import: ESLint plugin with rules that help validate proper imports.](https://github.com/import-js/eslint-plugin-import?tab=readme-ov-file#importparsers)
