### PR TITLE
chore: Correct LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,4 +180,4 @@ npm uninstall eslint-plugin-promise eslint-plugin-import \
 
 ## License
 
-Open source [licensed as MIT](https://github.com/iamturns/eslint-config-airbnb-typescript/blob/master/LICENSE).
+Open source [licensed as MIT](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/LICENSE).


### PR DESCRIPTION
## What changed / motivation ?

The link to the LICENSE file in the README is for Airbnb's. https://github.com/iamturns/eslint-config-airbnb-typescript/blob/master/LICENSE
We have the LICENSE file in this repository, so this patch replaces the link with the file in this repository.


BTW, if this repository is based on the airbnb's code, this repository probably violates the airbnb's license. We should add the upstream copyright to the LICENSE file in this case. 
https://github.com/moneyforward/eslint-config-moneyforward/blob/main/LICENSE#L3
But I'm not sure the code originated from Airbnb. Therefore, I haven't changed the LICENSE file in this PR.

## Linked PR / Issues

nothing


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->
