### PR TITLE
ci: Specify release rules

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -4,7 +4,15 @@
 module.exports = {
   branches: ['main'],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        releaseRules: [
+          { type: 'chore', release: 'patch' },
+          { type: 'docs', release: 'patch' },
+        ],
+      },
+    ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/npm',

--- a/release.config.js
+++ b/release.config.js
@@ -8,8 +8,8 @@ module.exports = {
       '@semantic-release/commit-analyzer',
       {
         releaseRules: [
-          { type: 'chore', release: 'patch' },
-          { type: 'docs', release: 'patch' },
+          { type: 'docs', scope: 'README', release: 'patch' },
+          { type: 'docs', scope: 'LICENSE', release: 'patch' },
         ],
       },
     ],


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

By default, [only commit messages of type `feat`, `fix`, and `perf` are associated](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js#L10-L12) with a release.

However, it is desirable for commits of type `docs` and scope `README` or `LICENSE` to also be associated with a release, because `README.md` and `LICENSE` files are included in Node packages.

> [!important]
> This pull request has been created to allow the last updated README (#316) to be released  as the next version.
> However, that update was committed as type `chore`. It should have been committed as type `docs(README)`, so the commit message needs to be revised.
> ```diff
> - chore: Correct LICENSE link in README (#316)
> + docs(README): Correct LICENSE link in README (#316)
> ```

## Linked PR / Issues

<!-- Fixes # (issue) -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->

- [semantic-release/commit-analyzer: :bulb: semantic-release plugin to analyze commits with conventional-changelog](https://github.com/semantic-release/commit-analyzer?tab=readme-ov-file#releaserules)
- https://moneyforward.slack.com/archives/C0296U7ERU3/p1724836436032499