### PR TITLE
ci: Implement `dry-run` option for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Verifying the signatures
-        run: npm audit signatures
-
       - name: Release
         run: npm run release ${{ github.event.inputs.dry_run == 'true' && '-- --dry-run' || '' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: dry-run
+        required: true
+        type: boolean
 
 permissions:
   contents: write
@@ -33,8 +38,11 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Verifying the signatures
+        run: npm audit signatures
+
       - name: Release
-        run: npm run release
+        run: npm run release ${{ github.event.inputs.dry_run == 'true' && '-- --dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

It would be nice to be able to confirm the next version number of this package in CI/CD before releasing it to production.

To achieve this, the `dry-run` option has been implemented in the release workflow.

## Linked PR / Issues

<!-- Fixes # (issue) -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->

- [Configuration | semantic-release](https://semantic-release.gitbook.io/semantic-release/usage/configuration#dryrun)
- [Workflow syntax for GitHub Actions - GitHub Enterprise Cloud Docs](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/workflow-syntax-for-github-actions#example-of-onworkflow_dispatchinputs)
