### PR TITLE
docs: Add troubleshooting directory and add new document for tsconfig parser error

### DIFF
--- a/docs/troubleshooting/eslint-configuration-issue-with-non-standard-tsconfig-filenames-in-flat-config.md
+++ b/docs/troubleshooting/eslint-configuration-issue-with-non-standard-tsconfig-filenames-in-flat-config.md
@@ -1,0 +1,39 @@
+# ESLint Configuration Issue with Non-Standard TSConfig Filenames in Flat Config
+
+When using a TSConfig filename other than `tsconfig.json` (e.g., `tsconfig.app.json`) in Flat Config, ESLint may not function correctly.
+
+## Problem
+
+Running ESLint might result in an error similar to:
+
+```text
+  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/src/App.tsx` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
+However, that TSConfig does not include this file. Either:
+- Change ESLint's list of included files to not include this file
+- Change that TSConfig to include this file
+- Create a new TSConfig that includes this file and include it in your parserOptions.project
+See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
+```
+
+## Solution
+
+In your `eslint.config.mjs` (or other ESLint configuration file), ensure that `parserOptions.project` is correctly set:
+
+```js:Example of flat config
+export default [
+  // ...other configurations
+  {
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.app.json",
+      },
+    },
+  },
+];
+```
+
+This configuration allows ESLint to reference the correct TSConfig file, which should resolve the issue.
+
+## Notes
+
+- Depending on your project structure, you might need to use an array or glob pattern for `parserOptions.project` to specify multiple TSConfig files.


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

The issue of parsing tsconfig.hoge.json will occur in several environment, but it is difficult to solve it in this library. So we decided to add a troubleshooting guideline for this problem.

## Linked PR / Issues

<!-- Fixes # (issue) -->

The troubleshooting guide for #322

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->

- #322
- [Relative TSConfig Projects with `parserOptions.project = true` | typescript-eslint](https://typescript-eslint.io/blog/parser-options-project-true/#whats-next)