### PR TITLE
fix: Disable `import/no-default-export` rule in `.storybook/` directory

### DIFF
--- a/configs/flat/storybook.mjs
+++ b/configs/flat/storybook.mjs
@@ -15,7 +15,10 @@ export default [
   ...storybook.configs['flat/csf-strict'],
 
   {
-    files: ['**/*.@(stories|story).@(ts|tsx|js|jsx|mjs|cjs)'],
+    files: [
+      '**/*.@(stories|story).@(ts|tsx|js|jsx|mjs|cjs)',
+      '**/.storybook/**/*.@(ts|tsx|js|jsx)',
+    ],
     rules: {
       'import/no-default-export': ['off'],
     },


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

[Files in `.storybook/` directory](https://storybook.js.org/docs/configure) must be exempt from [`import/no-default-export` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md). The `.eslintrc` config had this set properly, but the flat config was missing this setting.

## Linked PR / Issues

<!-- Fixes # (issue) -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->
