### PR TITLE
feat(eslint-config)!: enable recommended react-hooks rules from v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,15 @@ name: test
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Initialize
         uses: ./.github/actions/restore-node

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 
 # Visual Studio Code
 .vscode/*
+
+# Claude settings
+.claude/settings.local.json

--- a/packages/eslint-config/configs/flat/react.mjs
+++ b/packages/eslint-config/configs/flat/react.mjs
@@ -21,6 +21,7 @@ const reactHooksRuleSet = {
     'react-hooks': reactHooks,
   },
   rules: {
+    ...reactHooks.configs.flat.recommended.rules,
     ...reactHooksRuleSetBase.rules,
   },
 };
@@ -38,7 +39,7 @@ const jsxA11yRuleSet = {
 export default [
   {
     languageOptions: {
-      ...react.configs.recommended.languageOptions,
+      ...react.configs.flat?.recommended.languageOptions,
     },
 
     settings: {

--- a/packages/eslint-config/rules/react-hooks.js
+++ b/packages/eslint-config/rules/react-hooks.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: ['react-hooks'],
+  extends: ['plugin:react-hooks/recommended'],
 
   rules: {
     // Verify the list of the dependencies for Hooks like useEffect and similar.

--- a/packages/eslint-config/tests/snapshot-test/eslintrc/next/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/eslintrc/next/__snapshots__/snapshot.test.js.snap
@@ -2244,10 +2244,55 @@ exports[`should match ESLint configuration snapshot: next 1`] = `
     "radix": [
       2,
     ],
+    "react-hooks/component-hook-factories": [
+      2,
+    ],
+    "react-hooks/config": [
+      2,
+    ],
+    "react-hooks/error-boundaries": [
+      2,
+    ],
     "react-hooks/exhaustive-deps": [
       2,
     ],
+    "react-hooks/gating": [
+      2,
+    ],
+    "react-hooks/globals": [
+      2,
+    ],
+    "react-hooks/immutability": [
+      2,
+    ],
+    "react-hooks/incompatible-library": [
+      1,
+    ],
+    "react-hooks/preserve-manual-memoization": [
+      2,
+    ],
+    "react-hooks/purity": [
+      2,
+    ],
+    "react-hooks/refs": [
+      2,
+    ],
     "react-hooks/rules-of-hooks": [
+      2,
+    ],
+    "react-hooks/set-state-in-effect": [
+      2,
+    ],
+    "react-hooks/set-state-in-render": [
+      2,
+    ],
+    "react-hooks/static-components": [
+      2,
+    ],
+    "react-hooks/unsupported-syntax": [
+      1,
+    ],
+    "react-hooks/use-memo": [
       2,
     ],
     "react/boolean-prop-naming": [

--- a/packages/eslint-config/tests/snapshot-test/eslintrc/react/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/eslintrc/react/__snapshots__/snapshot.test.js.snap
@@ -2181,10 +2181,55 @@ exports[`should match ESLint configuration snapshot: react 1`] = `
     "radix": [
       2,
     ],
+    "react-hooks/component-hook-factories": [
+      2,
+    ],
+    "react-hooks/config": [
+      2,
+    ],
+    "react-hooks/error-boundaries": [
+      2,
+    ],
     "react-hooks/exhaustive-deps": [
       2,
     ],
+    "react-hooks/gating": [
+      2,
+    ],
+    "react-hooks/globals": [
+      2,
+    ],
+    "react-hooks/immutability": [
+      2,
+    ],
+    "react-hooks/incompatible-library": [
+      1,
+    ],
+    "react-hooks/preserve-manual-memoization": [
+      2,
+    ],
+    "react-hooks/purity": [
+      2,
+    ],
+    "react-hooks/refs": [
+      2,
+    ],
     "react-hooks/rules-of-hooks": [
+      2,
+    ],
+    "react-hooks/set-state-in-effect": [
+      2,
+    ],
+    "react-hooks/set-state-in-render": [
+      2,
+    ],
+    "react-hooks/static-components": [
+      2,
+    ],
+    "react-hooks/unsupported-syntax": [
+      1,
+    ],
+    "react-hooks/use-memo": [
       2,
     ],
     "react/boolean-prop-naming": [

--- a/packages/eslint-config/tests/snapshot-test/eslintrc/storybook/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/eslintrc/storybook/__snapshots__/snapshot.test.js.snap
@@ -1938,11 +1938,56 @@ exports[`should match ESLint configuration snapshot: storybook 1`] = `
     "radix": [
       2,
     ],
+    "react-hooks/component-hook-factories": [
+      2,
+    ],
+    "react-hooks/config": [
+      2,
+    ],
+    "react-hooks/error-boundaries": [
+      2,
+    ],
     "react-hooks/exhaustive-deps": [
+      2,
+    ],
+    "react-hooks/gating": [
+      2,
+    ],
+    "react-hooks/globals": [
+      2,
+    ],
+    "react-hooks/immutability": [
+      2,
+    ],
+    "react-hooks/incompatible-library": [
+      1,
+    ],
+    "react-hooks/preserve-manual-memoization": [
+      2,
+    ],
+    "react-hooks/purity": [
+      2,
+    ],
+    "react-hooks/refs": [
       2,
     ],
     "react-hooks/rules-of-hooks": [
       0,
+    ],
+    "react-hooks/set-state-in-effect": [
+      2,
+    ],
+    "react-hooks/set-state-in-render": [
+      2,
+    ],
+    "react-hooks/static-components": [
+      2,
+    ],
+    "react-hooks/unsupported-syntax": [
+      1,
+    ],
+    "react-hooks/use-memo": [
+      2,
     ],
     "react/boolean-prop-naming": [
       0,

--- a/packages/eslint-config/tests/snapshot-test/flat/next/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/flat/next/__snapshots__/snapshot.test.js.snap
@@ -74,6 +74,9 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       "parseForESLint": [Function],
     },
     "parserOptions": {
+      "ecmaFeatures": {
+        "jsx": true,
+      },
       "ecmaVersion": "latest",
       "projectService": true,
       "sourceType": "module",
@@ -2468,10 +2471,55 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       2,
       "always",
     ],
+    "react-hooks/component-hook-factories": [
+      2,
+    ],
+    "react-hooks/config": [
+      2,
+    ],
+    "react-hooks/error-boundaries": [
+      2,
+    ],
     "react-hooks/exhaustive-deps": [
       2,
     ],
+    "react-hooks/gating": [
+      2,
+    ],
+    "react-hooks/globals": [
+      2,
+    ],
+    "react-hooks/immutability": [
+      2,
+    ],
+    "react-hooks/incompatible-library": [
+      1,
+    ],
+    "react-hooks/preserve-manual-memoization": [
+      2,
+    ],
+    "react-hooks/purity": [
+      2,
+    ],
+    "react-hooks/refs": [
+      2,
+    ],
     "react-hooks/rules-of-hooks": [
+      2,
+    ],
+    "react-hooks/set-state-in-effect": [
+      2,
+    ],
+    "react-hooks/set-state-in-render": [
+      2,
+    ],
+    "react-hooks/static-components": [
+      2,
+    ],
+    "react-hooks/unsupported-syntax": [
+      1,
+    ],
+    "react-hooks/use-memo": [
       2,
     ],
     "react/boolean-prop-naming": [

--- a/packages/eslint-config/tests/snapshot-test/flat/react/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/flat/react/__snapshots__/snapshot.test.js.snap
@@ -74,6 +74,9 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
       "parseForESLint": [Function],
     },
     "parserOptions": {
+      "ecmaFeatures": {
+        "jsx": true,
+      },
       "ecmaVersion": "latest",
       "projectService": true,
       "sourceType": "module",
@@ -2405,10 +2408,55 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
       2,
       "always",
     ],
+    "react-hooks/component-hook-factories": [
+      2,
+    ],
+    "react-hooks/config": [
+      2,
+    ],
+    "react-hooks/error-boundaries": [
+      2,
+    ],
     "react-hooks/exhaustive-deps": [
       2,
     ],
+    "react-hooks/gating": [
+      2,
+    ],
+    "react-hooks/globals": [
+      2,
+    ],
+    "react-hooks/immutability": [
+      2,
+    ],
+    "react-hooks/incompatible-library": [
+      1,
+    ],
+    "react-hooks/preserve-manual-memoization": [
+      2,
+    ],
+    "react-hooks/purity": [
+      2,
+    ],
+    "react-hooks/refs": [
+      2,
+    ],
     "react-hooks/rules-of-hooks": [
+      2,
+    ],
+    "react-hooks/set-state-in-effect": [
+      2,
+    ],
+    "react-hooks/set-state-in-render": [
+      2,
+    ],
+    "react-hooks/static-components": [
+      2,
+    ],
+    "react-hooks/unsupported-syntax": [
+      1,
+    ],
+    "react-hooks/use-memo": [
       2,
     ],
     "react/boolean-prop-naming": [

--- a/packages/eslint-config/tests/snapshot-test/flat/storybook/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/flat/storybook/__snapshots__/snapshot.test.js.snap
@@ -74,6 +74,9 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       "parseForESLint": [Function],
     },
     "parserOptions": {
+      "ecmaFeatures": {
+        "jsx": true,
+      },
       "ecmaVersion": "latest",
       "projectService": true,
       "sourceType": "module",
@@ -2162,11 +2165,56 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       2,
       "always",
     ],
+    "react-hooks/component-hook-factories": [
+      2,
+    ],
+    "react-hooks/config": [
+      2,
+    ],
+    "react-hooks/error-boundaries": [
+      2,
+    ],
     "react-hooks/exhaustive-deps": [
+      2,
+    ],
+    "react-hooks/gating": [
+      2,
+    ],
+    "react-hooks/globals": [
+      2,
+    ],
+    "react-hooks/immutability": [
+      2,
+    ],
+    "react-hooks/incompatible-library": [
+      1,
+    ],
+    "react-hooks/preserve-manual-memoization": [
+      2,
+    ],
+    "react-hooks/purity": [
+      2,
+    ],
+    "react-hooks/refs": [
       2,
     ],
     "react-hooks/rules-of-hooks": [
       0,
+    ],
+    "react-hooks/set-state-in-effect": [
+      2,
+    ],
+    "react-hooks/set-state-in-render": [
+      2,
+    ],
+    "react-hooks/static-components": [
+      2,
+    ],
+    "react-hooks/unsupported-syntax": [
+      1,
+    ],
+    "react-hooks/use-memo": [
+      2,
     ],
     "react/boolean-prop-naming": [
       0,


### PR DESCRIPTION
## What changed / motivation ?

Enable the new rule set shipped in `eslint-plugin-react-hooks` v6+ (the React Compiler era rules) as part of `eslint-config-moneyforward`. Previously only `exhaustive-deps` and `rules-of-hooks` were explicitly set to error; this change pulls in the plugin's full `recommended` preset so the shared config keeps up with current best practices.

### Changes

- `packages/eslint-config/configs/flat/react.mjs`
  - Spread `reactHooks.configs.flat.recommended.rules` to enable the new rules in the flat config
  - Switch `languageOptions` to reference `react.configs.flat?.recommended.languageOptions` so the flat-config JSX parser options are propagated correctly
- `packages/eslint-config/rules/react-hooks.js`
  - Add `extends: ['plugin:react-hooks/recommended']` for the eslintrc consumers
- Snapshot tests updated to reflect the new rule activations

### Newly activated rules

**Error level (13 new rules)**
- `react-hooks/component-hook-factories`
- `react-hooks/config`
- `react-hooks/error-boundaries`
- `react-hooks/gating`
- `react-hooks/globals`
- `react-hooks/immutability`
- `react-hooks/preserve-manual-memoization`
- `react-hooks/purity`
- `react-hooks/refs`
- `react-hooks/set-state-in-effect`
- `react-hooks/set-state-in-render`
- `react-hooks/static-components`
- `react-hooks/use-memo`

**Warn level (2 new rules)**
- `react-hooks/incompatible-library`
- `react-hooks/unsupported-syntax`

### Impact on consumers and mitigations

Downstream projects may see new lint errors on existing React code. Suggested paths:

1. Review each reported issue and fix the code where feasible.
2. For rules that are difficult to adopt immediately, override them in the project's ESLint config:
   ```js
   // e.g. eslint.config.mjs
   export default [
     // ...
     {
       rules: {
         'react-hooks/purity': 'off',
       },
     },
   ];
   ```

## Linked PR / Issues

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

### Versioning

Per the [Versioning policy in the package README](https://github.com/moneyforward/frontend-tools/blob/main/packages/eslint-config/README.md#versioning), changes that add error-level rules require a **major bump (5.1.4 → 6.0.0)**. The commit message uses \`feat(eslint-config)!\` and a \`BREAKING CHANGE:\` footer so semantic-release will produce v6.0.0 automatically.

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks)
- [React Compiler ESLint rules](https://react.dev/learn/react-compiler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)