### PR TITLE
chore: pin GitHub Actions to SHA (incident 2026-04-28)

### DIFF
--- a/.github/workflows/check_pull_request_title.yml
+++ b/.github/workflows/check_pull_request_title.yml
@@ -15,7 +15,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
Replaces tag/branch references in workflow files with commit SHAs reachable at or before 2026-04-28T00:00:00Z.

## Why
Mitigates the supply-chain risk of mutable tag/branch references in third-party GitHub Actions following the 2026-04-28 incident. Tag references can be force-updated by upstream maintainers; SHAs are immutable.

## How
- Original version is preserved as a trailing comment (e.g. `uses: foo/bar@<sha> # v1`) so Renovate / Dependabot can still detect upstream upgrades.
- SHAs were pre-resolved and verified by the upstream pipeline (resolve_sha.py + verify_sha.py).

## Test plan
- [ ] CI green
- [ ] Workflow files diff-reviewed for unintended changes
