### PR TITLE
ci: add helper to pin GitHub Action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:js-lib", ":semanticCommits"],
+  "extends": [
+    "config:js-lib",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
   "timezone": "Asia/Tokyo",
   "labels": ["dependencies"],
   "schedule": ["before 4am on the first day of the month"],


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

This PR updates the Renovate Configuration to enhance the security of GitHub Actions dependencies by pinning to specific digests.

Dependency management improvements:

- Updated `renovate.json` to extend the `helpers:pinGitHubActionDigests` preset, ensuring that GitHub Actions are pinned to specific digests for improved security and reproductivity.

## Linked PR / Issues

<!-- Fixes # (issue) -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->
