### PR TITLE
chore: pin GitHub Actions to SHA (action_sha_pining_github_leak_2026)

### DIFF
--- a/.github/actions/restore-node/action.yml
+++ b/.github/actions/restore-node/action.yml
@@ -6,15 +6,15 @@ runs:
   using: 'composite'
   steps:
     - name: Setup node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: ./.node-version
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6.0.0
+      uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
     - name: cache node_modules
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ./node_modules

--- a/.github/workflows/check_pull_request_title.yml
+++ b/.github/workflows/check_pull_request_title.yml
@@ -15,7 +15,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
## Summary
Replaces tag/branch references in workflow files with commit SHAs.

- Third-party actions are pinned via [pinact](https://github.com/suzuki-shunsuke/pinact).
- `moneyforward/*` actions are pinned to the latest commit SHA of whatever
  ref is currently specified (version tag or branch).

## Why
Mitigates the supply-chain risk of mutable tag/branch references in
GitHub Actions. SHAs are immutable; tags are not.

## Test plan
- [ ] CI green
- [ ] Workflow files diff-reviewed for unintended changes
