### PR TITLE
test(stylelint-config): drop pluginFunctions from resolveConfig snapshots

### DIFF
--- a/packages/stylelint-config/configs/scss.js
+++ b/packages/stylelint-config/configs/scss.js
@@ -1,3 +1,3 @@
 export default {
-  extends: ["stylelint-config-standard-scss"],
+  extends: ['stylelint-config-standard-scss'],
 };

--- a/packages/stylelint-config/test/css-modules/__snapshots__/snapshot.test.ts.snap
+++ b/packages/stylelint-config/test/css-modules/__snapshots__/snapshot.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`should match Stylelint Configuration snapshot: css-modules 1`] = `
 {
-  "pluginFunctions": undefined,
   "rules": {
     "alpha-value-notation": [
       "percentage",

--- a/packages/stylelint-config/test/css-modules/snapshot.test.ts
+++ b/packages/stylelint-config/test/css-modules/snapshot.test.ts
@@ -1,11 +1,11 @@
-import path from "node:path";
-import stylelint from "stylelint";
+import path from 'node:path';
+import stylelint from 'stylelint';
 
-test("should match Stylelint Configuration snapshot: css-modules", async () => {
-  const { rules, pluginFunctions } =
+test('should match Stylelint Configuration snapshot: css-modules', async () => {
+  const { rules } =
     (await stylelint.resolveConfig(
-      path.resolve(import.meta.dirname, "./stylelint.config.js")
+      path.resolve(import.meta.dirname, './stylelint.config.js'),
     )) ?? {};
 
-  expect({ rules, pluginFunctions }).toMatchSnapshot();
+  expect({ rules }).toMatchSnapshot();
 });

--- a/packages/stylelint-config/test/css-modules/stylelint.config.js
+++ b/packages/stylelint-config/test/css-modules/stylelint.config.js
@@ -1,4 +1,4 @@
 // @ts-check
 export default {
-  extends: ["../../configs/essentials.js", "../../configs/css-modules.js"],
+  extends: ['../../configs/essentials.js', '../../configs/css-modules.js'],
 };

--- a/packages/stylelint-config/test/css/__snapshots__/snapshot.test.ts.snap
+++ b/packages/stylelint-config/test/css/__snapshots__/snapshot.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`should match Stylelint Configuration snapshot: css 1`] = `
 {
-  "pluginFunctions": undefined,
   "rules": {
     "alpha-value-notation": [
       "percentage",

--- a/packages/stylelint-config/test/css/snapshot.test.ts
+++ b/packages/stylelint-config/test/css/snapshot.test.ts
@@ -1,11 +1,11 @@
-import path from "node:path";
-import stylelint from "stylelint";
+import path from 'node:path';
+import stylelint from 'stylelint';
 
-test("should match Stylelint Configuration snapshot: css", async () => {
-  const { rules, pluginFunctions } =
+test('should match Stylelint Configuration snapshot: css', async () => {
+  const { rules } =
     (await stylelint.resolveConfig(
-      path.resolve(import.meta.dirname, "./stylelint.config.js")
+      path.resolve(import.meta.dirname, './stylelint.config.js'),
     )) ?? {};
 
-  expect({ rules, pluginFunctions }).toMatchSnapshot();
+  expect({ rules }).toMatchSnapshot();
 });

--- a/packages/stylelint-config/test/scss/__snapshots__/snapshot.test.ts.snap
+++ b/packages/stylelint-config/test/scss/__snapshots__/snapshot.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`should match Stylelint Configuration snapshot: css 1`] = `
 {
-  "pluginFunctions": undefined,
   "rules": {
     "alpha-value-notation": [
       "percentage",

--- a/packages/stylelint-config/test/scss/snapshot.test.ts
+++ b/packages/stylelint-config/test/scss/snapshot.test.ts
@@ -1,11 +1,11 @@
-import path from "node:path";
-import stylelint from "stylelint";
+import path from 'node:path';
+import stylelint from 'stylelint';
 
-test("should match Stylelint Configuration snapshot: css", async () => {
-  const { rules, pluginFunctions } =
+test('should match Stylelint Configuration snapshot: css', async () => {
+  const { rules } =
     (await stylelint.resolveConfig(
-      path.resolve(import.meta.dirname, "./stylelint.config.js")
+      path.resolve(import.meta.dirname, './stylelint.config.js'),
     )) ?? {};
 
-  expect({ rules, pluginFunctions }).toMatchSnapshot();
+  expect({ rules }).toMatchSnapshot();
 });

--- a/packages/stylelint-config/test/scss/stylelint.config.js
+++ b/packages/stylelint-config/test/scss/stylelint.config.js
@@ -1,4 +1,4 @@
 // @ts-check
 export default {
-  extends: ["../../configs/essentials.js", "../../configs/scss.js"],
+  extends: ['../../configs/essentials.js', '../../configs/scss.js'],
 };

--- a/packages/stylelint-config/vitest.config.ts
+++ b/packages/stylelint-config/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineProject } from "vitest/config";
+import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
     globals: true,
-    include: ["test/**/*.test.ts"],
+    include: ['test/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## What changed / motivation ?

Applied Prettier formatting in stylelint-config test/config files and removed pluginFunctions from snapshot tests because this property is no longer returned by stylelint.resolveConfig.

## Linked PR / Issues

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that does not modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- stylelint resolveConfig return shape update (pluginFunctions removed)
