### PR TITLE
chore(eslint-config): allow typescript v6 in peer dependencies

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -79,7 +79,7 @@
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0",
     "jest": "*",
-    "typescript": "^4.8.4 || ^5.0.0"
+    "typescript": "^4.8.4 || ^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "jest": {


### PR DESCRIPTION
## What changed / motivation ?

Widen the `typescript` peer dependency range in `eslint-config-moneyforward` from `^4.8.4 || ^5.0.0` to `^4.8.4 || ^5.0.0 || ^6.0.0`.

TypeScript 6.0 is on the horizon, and with the previous range every consumer would hit a peer dependency warning the moment they upgrade — even though nothing in this config actually breaks. The pinned `typescript-eslint@8.67.0` already declares `typescript: ">=4.8.4 <6.1.0"`, so the typed-lint stack this config depends on covers the 6.x line.

## Linked PR / Issues

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- `typescript-eslint@8.67.0` peer range: `typescript: ">=4.8.4 <6.1.0"` (verified in the installed package under `node_modules/.pnpm`)

## Notes

This only relaxes a peer dependency range — no runtime or rule behaviour changes. Installs that already pass keep passing; TypeScript 6 users stop needing escape hatches like `--legacy-peer-deps`.