### PR TITLE
feat(claude): add compare-lint-rules skill and command

### DIFF
--- a/.claude/commands/compare-lint-rules.md
+++ b/.claude/commands/compare-lint-rules.md
@@ -1,0 +1,10 @@
+---
+description: Compare the eslint-config and oxlint-config snapshot test results, then list the rule mapping status, the differences, and what oxlint does not support
+argument-hint: <granularity> (essentials | typescript | nextjs | node | react | storybook | test.essentials | test.react)
+---
+
+Use the `compare-lint-rules` skill to compare how far the rule sets of `eslint-config-moneyforward` and `oxlint-config-moneyforward` map to each other.
+
+Granularity to compare: $ARGUMENTS
+
+When no granularity is given, offer `essentials` / `typescript` / `nextjs` / `node` / `react` / `storybook` / `test.essentials` / `test.react` and ask which one to compare. Do not batch several of them on your own.

--- a/.claude/skills/compare-lint-rules/SKILL.md
+++ b/.claude/skills/compare-lint-rules/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: compare-lint-rules
+description: Compares the snapshot test results of eslint-config-moneyforward and oxlint-config-moneyforward to judge, one granularity at a time, whether the oxlint rule sets map to the ESLint ones. Lists the differences (unset on the oxlint side, severity mismatches, enabled only on the oxlint side) and the rules oxlint does not support. Use when comparing essentials / typescript / nextjs / node / react / storybook / test.essentials / test.react, or when asked whether the rules are mapped or which rules oxlint cannot cover.
+---
+
+# eslint-config / oxlint-config rule mapping comparison
+
+`oxlint-config-moneyforward` re-implements `eslint-config-moneyforward` on top of oxlint. Every rule the oxlint side ships must map to an ESLint rule **unless there is no way around it, such as oxlint not supporting the rule**. This skill compares both packages' snapshot test results and judges how far that mapping has got, one granularity at a time.
+
+## Prerequisites
+
+This skill does not run the snapshot tests. It reads the **committed `.snap` files**, so the snapshot test for the target granularity must have been run beforehand. If it has not, point at these commands:
+
+```bash
+pnpm eslint-config test run test/flat/<dir>     # ESLint side
+pnpm oxlint-config test run src/configs/<dir>   # oxlint side
+```
+
+The script warns when a snapshot is older than the configuration it captures. When that warning appears, ask for the test to be re-run and state that the comparison is provisional.
+
+## Granularities and directories
+
+| Granularity             | ESLint                                        | oxlint                                          |
+| ----------------------- | --------------------------------------------- | ----------------------------------------------- |
+| `essentials`            | `packages/eslint-config/test/flat/essentials` | `packages/oxlint-config/src/configs/essentials` |
+| `typescript`            | `.../test/flat/typescript`                    | `.../src/configs/typescript`                    |
+| `nextjs` (alias `next`) | `.../test/flat/next`                          | `.../src/configs/nextjs`                        |
+| `node`                  | `.../test/flat/node`                          | `.../src/configs/node`                          |
+| `react`                 | `.../test/flat/react`                         | `.../src/configs/react`                         |
+| `storybook`             | `.../test/flat/storybook`                     | `.../src/configs/storybook`                     |
+| `test.essentials`       | `.../test/flat/test/essentials`               | `.../src/configs/test/essentials`               |
+| `test.react`            | `.../test/flat/test/react`                    | `.../src/configs/test/react`                    |
+
+`GRANULARITIES` in `scripts/lib/granularities.mjs` is the single source of truth for this table. Update it there when a directory is added.
+
+## Steps
+
+### 1. Pick the granularity
+
+Use the granularity passed as an argument. When none is given, offer the table above and let the user choose. **Never batch several granularities on your own** — the workflow is one granularity at a time.
+
+### 2. Run the comparison script
+
+```bash
+node .claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs <granularity>
+```
+
+Options:
+
+- `--json` — emit machine-readable JSON (useful for re-aggregating or filtering counts)
+- `--verbose` — also list the rules that are already mapped
+- `--eslint-snapshot <path>` / `--oxlint-snapshot <path>` — point at specific snapshot files
+- `--repo-root <path>` — set the repository root explicitly
+
+The script exits with code 2 when a `.snap` file is missing. Report which side's snapshot is absent, ask for the test to be created and run, and stop there. **This skill must not create snapshot tests.**
+
+### 3. Verify the output
+
+Do not report the script's mechanical classification as-is. Always check the following.
+
+1. **Whether both sides compose corresponding rule sets.** Compare the `ESLint 側構成` and `oxlint 側構成` lines in the report header. The ESLint side tests are sometimes cumulative (for example `[...essentials, ...react, ...typescript]`), and if the oxlint side only has `extends: [essentials]` then most of the difference comes from that mismatch rather than from missing rules. When they do not correspond, **say so first and make clear that the differences need careful reading**.
+
+2. **Cross-check the rules listed under 🚫 (not supported by oxlint).** When the "類似候補" (similar candidates) column shows the same rule name under another scope, the rule is probably supported and the scope mapping is what is missing. Check the catalog directly when needed:
+
+   ```bash
+   packages/oxlint-config/node_modules/.bin/oxlint --rules -f json | grep -i '<rule-name>'
+   ```
+
+   When a rule turns out to have merely been renamed or moved to another scope, propose adding it to `SCOPE_MAP` in `scripts/lib/ruleName.mjs` and re-running.
+
+3. **The plugin column under ❌ (unset on the oxlint side).** A row marked `未有効 (<scope>)` means the plugin is not enabled, so writing the rule alone would have no effect. Point out that the oxlint config's `plugins` may be incomplete.
+
+4. **How to treat the option differences.** **Options cannot be judged from the snapshots.** ESLint's `calculateConfigForFile()` fills in schema defaults (for example `no-extra-boolean-cast` is only `['error']` in `rules/errors.js`, yet the snapshot shows `[{}]`), and oxlint drops rule options from `--print-config` when object-form `extends` is used ([oxc#22230](https://github.com/oxc-project/oxc/issues/22230); runtime behaviour is unaffected). For this section only, the script therefore imports `eslint.config.mjs` / `oxlint.config.ts` instead of reading the snapshots.
+
+   An option being absent on the oxlint side **does not mean it is unhandled**: when the eslint-config value equals oxlint's default, the oxlint side omits it on purpose. The script consults `node_modules/oxlint/configuration_schema.json` (which carries a `default` per option), resolves oxlint's effective value as "the value the rule set writes, otherwise the schema default", and splits the differences three ways:
+
+   - **要対応 (needs work): effective values differ** — genuinely out of sync. Only these are actionable
+   - **判定不能 (undecidable): oxlint's default is unknown** — the schema has no `default` (positional enums, for instance) or no option definition for the rule at all. Check oxlint's documentation
+   - **実質一致 (equivalent)** — same as oxlint's default, so nothing to do
+
+   **Never conclude that an option is "unset on the oxlint side, therefore actionable".** Report the three groups as they are.
+
+### 4. Produce and save the report
+
+Base the output on the script's Markdown and post the following to the chat:
+
+- Open with a **conclusion** of about three lines: how many rules are mapped, how many need work, how many are unavoidable differences, and what to touch next
+- Follow with the script's sections (long tables may be trimmed to the essentials, but **state how many rows were omitted**)
+- Append the caveats found in step 3 (rule set mismatch, missing scope mapping, disabled plugin)
+
+Write the chat summary in the language the user is writing in. The script's own Markdown output is Japanese.
+
+Save the same content to `packages/oxlint-config/docs/mapping/<granularity>.md`, creating the directory when needed and overwriting an existing file. The raw script output does not match the repository's Prettier configuration, so format it after saving.
+
+```bash
+mkdir -p packages/oxlint-config/docs/mapping
+node .claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs <granularity> > packages/oxlint-config/docs/mapping/<granularity>.md
+# after prepending the conclusion section
+./node_modules/.bin/prettier --write packages/oxlint-config/docs/mapping/<granularity>.md
+```
+
+Tell the user where the report was saved.
+
+## What each classification means
+
+| Classification                         | Meaning and handling                                                                                                                        |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ mapped                              | Same rule, same severity. Nothing to do                                                                                                     |
+| ❌ unset on the oxlint side            | Enabled in ESLint but unset or `allow` in oxlint. **oxlint supports it, so this is actionable**                                             |
+| 🚫 not supported by oxlint             | Absent from oxlint's rule catalog. Record as an **unavoidable difference**                                                                  |
+| ⚠️ severity mismatch                   | Enabled on both sides but `warn` / `error` disagree. Decide which is correct and align them                                                 |
+| ➕ off in ESLint but enabled in oxlint | oxlint enables something ESLint deliberately disables. **Likely to produce reports the ESLint setup never had**                             |
+| ➕ enabled only in oxlint              | No corresponding ESLint rule. Either an oxlint-specific rule such as `oxc/*`, or a side effect of enabling whole `categories`               |
+| option differences                     | Severities agree but the written options differ. Read from the configuration sources, and **absent does not mean unhandled** (see step 3-4) |
+| off on both sides                      | Disabled on both sides. Counts only                                                                                                         |
+
+`oxlint --rules -f json` (the binary lives at `packages/oxlint-config/node_modules/.bin/oxlint`) is the source of truth for whether oxlint supports a rule. The catalog follows the installed oxlint version, so **updating oxlint can change the verdict**.
+
+## How the script works (for maintenance)
+
+`scripts/compare-lint-rules.mjs` only holds the CLI — argument parsing, I/O, and exiting on error. The judgement lives in `scripts/lib/`.
+
+| File                      | Responsibility                                                                    |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `lib/granularities.mjs`   | The granularity-to-directory table (`GRANULARITIES`)                              |
+| `lib/snapshot.mjs`        | Line oriented parser that reads `rules` / `plugins` out of a Vitest snapshot      |
+| `lib/catalog.mjs`         | The rule catalog from `oxlint --rules -f json`                                    |
+| `lib/optionSchema.mjs`    | Option defaults from `configuration_schema.json` and the three-way option verdict |
+| `lib/authoredOptions.mjs` | Collects the options as written in the configuration sources                      |
+| `lib/ruleName.mjs`        | ESLint name to oxlint name conversion (`SCOPE_MAP`)                               |
+| `lib/compare.mjs`         | Rule classification                                                               |
+| `lib/report.mjs`          | Markdown output                                                                   |
+| `lib/metadata.mjs`        | Snapshot freshness warnings and rule set composition                              |
+| `lib/util.mjs`            | `ComparisonError`, `stableStringify`, and friends                                 |
+
+- Expected failures (missing snapshot, missing oxlint binary, unparsable file) throw `ComparisonError`, which the CLI turns into a message on stderr and exit code 2. Nothing under `lib/` calls `process.exit`
+- Vitest snapshots cannot be `JSON.parse`d, because `pretty-format` leaves quotes inside strings unescaped (for example `"input[type="image"]"`). The parser relies on `pretty-format`'s deterministic layout — two space indentation, trailing commas — and never uses `eval`
+- `SCOPE_MAP` is the single source of truth for name conversion. Candidates are generated in priority order and resolved as **present in the resolved oxlint config → present in the catalog → the first candidate**, which absorbs scope drift such as `react-hooks/*` → `react/*` and `jest/*` ↔ `vitest/*`
+- Severities are normalised to `off` / `warn` / `error` from ESLint's `0` / `1` / `2` and oxlint's `allow` / `warn` / `deny`
+- Whether a rule is enabled, and at which severity, comes from the snapshots (file scoping is already resolved there, so they are accurate). **Options alone cannot be judged from the snapshots**, so `eslint.config.mjs` / `oxlint.config.ts` are imported and their `extends` chains walked, merging later definitions over earlier ones, to compare the options as written. Object key order is ignored (`stableStringify`)
+- The option verdict uses `node_modules/oxlint/configuration_schema.json`: `definitions.OxlintRules` → `DummyRuleMap.properties[<rule>]` holds each rule's option definition as a positional tuple, and each property's `default` is oxlint's default value

--- a/.claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+// @ts-check
+
+/**
+ * Compares the rule sets captured by the `eslint-config-moneyforward` and
+ * `oxlint-config-moneyforward` snapshot tests, and classifies every rule into
+ * "mapped", "severity mismatch", "missing on the oxlint side (but supported by
+ * oxlint)", "not supported by oxlint", and "oxlint only".
+ *
+ * Rule severities come from the committed Vitest snapshots, so the snapshot tests
+ * must have been run beforehand. `oxlint --rules -f json` is the source of truth
+ * for whether oxlint supports a rule at all, and rule options are read from both
+ * sides' configuration sources rather than the snapshots (see
+ * `lib/authoredOptions.mjs`).
+ *
+ * Usage:
+ *   node .claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs <granularity> [options]
+ *
+ * Options:
+ *   --json                     Emits machine-readable JSON instead of Markdown.
+ *   --verbose                  Lists every mapped rule instead of only counting them.
+ *   --eslint-snapshot <path>   Overrides the ESLint side snapshot file.
+ *   --oxlint-snapshot <path>   Overrides the oxlint side snapshot file.
+ *   --repo-root <path>         Overrides repository root detection.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { loadAuthoredOptions } from './lib/authoredOptions.mjs';
+import { loadCatalog } from './lib/catalog.mjs';
+import { compare } from './lib/compare.mjs';
+import { granularityNames, resolveGranularity } from './lib/granularities.mjs';
+import { collectWarnings, readComposition } from './lib/metadata.mjs';
+import { loadOptionSchema } from './lib/optionSchema.mjs';
+import { renderMarkdown } from './lib/report.mjs';
+import { readSections } from './lib/snapshot.mjs';
+import { ComparisonError } from './lib/util.mjs';
+
+try {
+  await main();
+} catch (error) {
+  if (!(error instanceof ComparisonError)) {
+    throw error;
+  }
+
+  process.stderr.write(
+    `${error.message}\n${error.showUsage ? `\n${usage()}` : ''}`,
+  );
+  process.exit(2);
+}
+
+async function main() {
+  const options = parseArgv(process.argv.slice(2));
+
+  if (options.help) {
+    process.stdout.write(usage());
+
+    return;
+  }
+
+  const repoRoot = options.repoRoot ?? findRepoRoot();
+  const { eslintDir, granularity, oxlintDir } = resolveGranularity(
+    options.granularity,
+  );
+  const eslintDirAbs = path.join(repoRoot, eslintDir);
+  const oxlintDirAbs = path.join(repoRoot, oxlintDir);
+  const eslintSnapshot =
+    options.eslintSnapshot ??
+    path.join(eslintDirAbs, '__snapshots__/snapshot.test.mts.snap');
+  const oxlintSnapshot =
+    options.oxlintSnapshot ??
+    path.join(oxlintDirAbs, '__snapshots__/snapshot.test.ts.snap');
+
+  requireSnapshots(granularity, repoRoot, [eslintSnapshot, oxlintSnapshot]);
+
+  const eslintRules = readSections(eslintSnapshot, 'ESLint', ['rules']).rules;
+  const { plugins, rules: oxlintRules } = readSections(
+    oxlintSnapshot,
+    'oxlint',
+    ['rules', 'plugins'],
+  );
+  const oxlintPlugins = new Set(Array.isArray(plugins) ? plugins : []);
+  const authoredEslint = await loadAuthoredOptions('eslint', eslintDirAbs);
+  const authoredOxlint = await loadAuthoredOptions('oxlint', oxlintDirAbs);
+
+  const result = compare({
+    authored: {
+      eslint: authoredEslint.options,
+      oxlint: authoredOxlint.options,
+    },
+    catalog: loadCatalog(repoRoot),
+    eslintRules,
+    optionSchema: loadOptionSchema(repoRoot),
+    oxlintPlugins,
+    oxlintRules,
+  });
+
+  const meta = {
+    authoredOptionsErrors: [authoredEslint.error, authoredOxlint.error].filter(
+      (error) => error !== null,
+    ),
+    eslintComposition: readComposition(
+      path.join(eslintDirAbs, 'eslint.config.mjs'),
+      /export default (\[[\s\S]*?\]);/,
+    ),
+    eslintRuleCount: Object.keys(eslintRules).length,
+    eslintSnapshot: path.relative(repoRoot, eslintSnapshot),
+    granularity,
+    oxlintComposition: readComposition(
+      path.join(oxlintDirAbs, 'oxlint.config.ts'),
+      /extends:\s*(\[[\s\S]*?\])/,
+    ),
+    oxlintPlugins: [...oxlintPlugins],
+    oxlintRuleCount: Object.keys(oxlintRules).length,
+    oxlintSnapshot: path.relative(repoRoot, oxlintSnapshot),
+    warnings: collectWarnings({
+      eslintDirAbs,
+      eslintSnapshot,
+      oxlintDirAbs,
+      oxlintSnapshot,
+      repoRoot,
+    }),
+  };
+
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify({ ...meta, ...result }, null, 2)}\n`
+      : renderMarkdown(meta, result, options),
+  );
+}
+
+/**
+ * @param {string} granularity The granularity being compared.
+ *
+ * @param {string} repoRoot Absolute path to the repository root.
+ *
+ * @param {string[]} snapshots Snapshot files both sides need.
+ *
+ * @returns {void}
+ *
+ * @throws {ComparisonError} When a snapshot is missing.
+ */
+function requireSnapshots(granularity, repoRoot, snapshots) {
+  const missing = snapshots.filter((file) => !fs.existsSync(file));
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  throw new ComparisonError(
+    [
+      `snapshot ファイルが見つかりません（粒度: ${granularity}）:`,
+      ...missing.map((file) => `  - ${path.relative(repoRoot, file)}`),
+      '',
+      '該当粒度の snapshot テストを作成・実行してから再実行してください。',
+    ].join('\n'),
+  );
+}
+
+/**
+ * @param {string[]} argv Raw command line arguments.
+ *
+ * @returns {{eslintSnapshot?: string, granularity?: string, help: boolean, json: boolean, oxlintSnapshot?: string, repoRoot?: string, verbose: boolean}} Parsed options.
+ */
+function parseArgv(argv) {
+  /** @type {any} */
+  const options = { help: false, json: false, verbose: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--json':
+        options.json = true;
+        break;
+      case '--verbose':
+        options.verbose = true;
+        break;
+      case '--eslint-snapshot':
+        options.eslintSnapshot = path.resolve(argv[(index += 1)]);
+        break;
+      case '--oxlint-snapshot':
+        options.oxlintSnapshot = path.resolve(argv[(index += 1)]);
+        break;
+      case '--repo-root':
+        options.repoRoot = path.resolve(argv[(index += 1)]);
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new ComparisonError(`不明なオプション: ${arg}`, {
+            showUsage: true,
+          });
+        }
+
+        options.granularity ??= arg;
+    }
+  }
+
+  return options;
+}
+
+/**
+ * @returns {string} The usage text.
+ */
+function usage() {
+  return [
+    'Usage: node .claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs <granularity> [options]',
+    '',
+    `granularity: ${granularityNames().join(' | ')}`,
+    '',
+    'Options:',
+    '  --json                     JSON で出力する',
+    '  --verbose                  マッピング済みルールも一覧表示する',
+    '  --eslint-snapshot <path>   ESLint 側 snapshot ファイルを指定する',
+    '  --oxlint-snapshot <path>   oxlint 側 snapshot ファイルを指定する',
+    '  --repo-root <path>         リポジトリルートを指定する',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Walks up from this script until the directory that holds both packages.
+ *
+ * @returns {string} Absolute path to the repository root.
+ */
+function findRepoRoot() {
+  let current = import.meta.dirname;
+
+  while (true) {
+    if (
+      fs.existsSync(path.join(current, 'packages/eslint-config')) &&
+      fs.existsSync(path.join(current, 'packages/oxlint-config'))
+    ) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+
+    if (parent === current) {
+      throw new ComparisonError(
+        'リポジトリルートを特定できませんでした。--repo-root で指定してください。',
+      );
+    }
+
+    current = parent;
+  }
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/authoredOptions.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/authoredOptions.mjs
@@ -1,0 +1,92 @@
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * @typedef {{error: string | null, options: Map<string, unknown[]> | null}} AuthoredOptions
+ */
+
+/**
+ * Collects the rule options as they are written in each side's configuration
+ * source.
+ *
+ * Neither snapshot can answer this question. ESLint's resolved config fills in
+ * every rule's schema defaults, so its snapshot cannot distinguish a deliberate
+ * option from a default. oxlint strips rule options from `--print-config` when
+ * object-form `extends` is used, so its snapshot shows no options at all even
+ * when the rule set defines them
+ * (https://github.com/oxc-project/oxc/issues/22230).
+ *
+ * A failure here is not fatal: the caller reports the option section as
+ * undecidable and keeps the rest of the comparison.
+ *
+ * @param {'eslint' | 'oxlint'} side Which side to load.
+ *
+ * @param {string} dir Absolute path to the side's config directory.
+ *
+ * @returns {Promise<AuthoredOptions>} The authored options keyed by rule name,
+ * or an error message when the source could not be loaded.
+ */
+export async function loadAuthoredOptions(side, dir) {
+  const entry = path.join(
+    dir,
+    side === 'eslint' ? 'eslint.config.mjs' : 'oxlint.config.ts',
+  );
+
+  if (!fs.existsSync(entry)) {
+    return { error: `${entry} が見つかりません`, options: null };
+  }
+
+  // The ESLint side reads this when building parser options at module load.
+  process.env.TSCONFIG_ROOT_DIR ??= '/dummy';
+
+  try {
+    const loaded = await import(pathToFileURL(entry).href);
+    const options = new Map();
+
+    collectAuthoredRules(loaded.default, options);
+
+    return { error: null, options };
+  } catch (error) {
+    return {
+      error: `${path.basename(entry)} を読み込めませんでした: ${error instanceof Error ? error.message : String(error)}`,
+      options: null,
+    };
+  }
+}
+
+/**
+ * Walks a flat ESLint config array or an oxlint config object, merging every
+ * `rules` map in resolution order so that later definitions win.
+ *
+ * oxlint's `overrides` are deliberately skipped: they are file scoped and are not
+ * part of the baseline the comparison is about.
+ *
+ * @param {any} config A config array, config object, or `extends` entry.
+ *
+ * @param {Map<string, unknown[]>} into Accumulator keyed by rule name.
+ *
+ * @returns {void}
+ */
+function collectAuthoredRules(config, into) {
+  if (!config || typeof config !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(config)) {
+    for (const entry of config) {
+      collectAuthoredRules(entry, into);
+    }
+
+    return;
+  }
+
+  // oxlint resolves `extends` before the config's own rules.
+  collectAuthoredRules(config.extends, into);
+
+  for (const [rule, value] of Object.entries(config.rules ?? {})) {
+    into.set(rule, Array.isArray(value) ? value.slice(1) : []);
+  }
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/catalog.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/catalog.mjs
@@ -1,0 +1,84 @@
+// @ts-check
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ComparisonError } from './util.mjs';
+
+/**
+ * @typedef {{category: string, docs_url: string, name: string, scope: string, type_aware: boolean, value: string}} CatalogEntry
+ */
+
+/**
+ * @typedef {{byBaseName: Map<string, string[]>, byName: Map<string, CatalogEntry>}} Catalog
+ */
+
+/**
+ * Loads every rule oxlint has registered. This is the source of truth for
+ * whether oxlint supports a rule at all, so it follows the oxlint version
+ * installed in `packages/oxlint-config`.
+ *
+ * @param {string} repoRoot Absolute path to the repository root.
+ *
+ * @returns {Catalog} The catalog indexed by configuration name (`scope/rule`,
+ * unprefixed for oxlint's `eslint` scope) and by bare rule name.
+ */
+export function loadCatalog(repoRoot) {
+  const stdout = execFileSync(
+    findOxlintBinary(repoRoot),
+    ['--rules', '-f', 'json'],
+    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+  );
+
+  /** @type {CatalogEntry[]} */
+  const entries = JSON.parse(stdout);
+  const byName = new Map();
+  const byBaseName = new Map();
+
+  for (const entry of entries) {
+    const scope = toConfigScope(entry.scope);
+    const name = scope ? `${scope}/${entry.value}` : entry.value;
+
+    byName.set(name, { ...entry, name, scope });
+    byBaseName.set(entry.value, [...(byBaseName.get(entry.value) ?? []), name]);
+  }
+
+  return { byBaseName, byName };
+}
+
+/**
+ * Converts a catalog scope into the prefix used in configuration files.
+ *
+ * @param {string} scope A scope as reported by `oxlint --rules`.
+ *
+ * @returns {string} The configuration prefix, empty for oxlint's `eslint` scope.
+ */
+function toConfigScope(scope) {
+  return scope === 'eslint' ? '' : scope.replace(/_/g, '-');
+}
+
+/**
+ * @param {string} repoRoot Absolute path to the repository root.
+ *
+ * @returns {string} Absolute path to an oxlint executable.
+ */
+function findOxlintBinary(repoRoot) {
+  const candidates = [
+    'packages/oxlint-config/node_modules/.bin/oxlint',
+    'packages/oxlint-config/node_modules/oxlint/bin/oxlint',
+    'node_modules/.bin/oxlint',
+  ].map((candidate) => path.join(repoRoot, candidate));
+  const binary = candidates.find((candidate) => fs.existsSync(candidate));
+
+  if (!binary) {
+    throw new ComparisonError(
+      [
+        'oxlint の実行ファイルが見つかりませんでした。',
+        '`pnpm install` を実行してから再実行してください。',
+      ].join('\n'),
+    );
+  }
+
+  return binary;
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/compare.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/compare.mjs
@@ -1,0 +1,268 @@
+// @ts-check
+
+import { judgeOptionDiff } from './optionSchema.mjs';
+import { canonicalize, splitRuleName } from './ruleName.mjs';
+import { stableStringify } from './util.mjs';
+
+/**
+ * @typedef {'error' | 'off' | 'warn'} Severity
+ */
+
+/** @type {Record<Severity, number>} */
+const SEVERITY_ORDER = { off: 0, warn: 1, error: 2 };
+
+/**
+ * @param {unknown} severity A raw severity from either side.
+ *
+ * @returns {Severity} The normalised severity. ESLint uses `0` / `1` / `2` and
+ * oxlint uses `allow` / `warn` / `deny`.
+ */
+function normalizeSeverity(severity) {
+  switch (severity) {
+    case 0:
+    case 'off':
+    case 'allow':
+      return 'off';
+    case 1:
+    case 'warn':
+      return 'warn';
+    case 2:
+    case 'error':
+    case 'deny':
+      return 'error';
+    default:
+      return 'error';
+  }
+}
+
+/**
+ * @param {unknown} value A rule entry from either snapshot.
+ *
+ * @returns {Severity} The entry's normalised severity.
+ */
+function severityOf(value) {
+  return normalizeSeverity(Array.isArray(value) ? value[0] : value);
+}
+
+/**
+ * Groups the ESLint rules by the oxlint name they map to. Two ESLint rules can
+ * canonicalise to the same oxlint rule (`react/*` and `react-hooks/*` both live
+ * in oxlint's `react` scope), in which case the strictest severity wins.
+ *
+ * @param {Record<string, unknown>} eslintRules Rules from the ESLint snapshot.
+ *
+ * @param {Set<string>} configured Rule names present in the oxlint config.
+ *
+ * @param {Map<string, unknown>} catalogByName The oxlint rule catalog.
+ *
+ * @returns {Map<string, {candidates: string[], eslintNames: string[], severity: Severity}>} The
+ * grouped ESLint side, keyed by canonical oxlint name.
+ */
+function groupByCanonical(eslintRules, configured, catalogByName) {
+  const grouped = new Map();
+
+  for (const [rule, value] of Object.entries(eslintRules)) {
+    const { candidates, name } = canonicalize(rule, configured, catalogByName);
+    const severity = severityOf(value);
+    const existing = grouped.get(name);
+
+    if (!existing) {
+      grouped.set(name, { candidates, eslintNames: [rule], severity });
+      continue;
+    }
+
+    existing.eslintNames.push(rule);
+
+    if (SEVERITY_ORDER[severity] > SEVERITY_ORDER[existing.severity]) {
+      existing.severity = severity;
+    }
+  }
+
+  return grouped;
+}
+
+/**
+ * Classifies every rule of both sides.
+ *
+ * @param {{authored: {eslint: Map<string, unknown[]> | null, oxlint: Map<string, unknown[]> | null}, catalog: import('./catalog.mjs').Catalog, eslintRules: Record<string, unknown>, optionSchema: import('./optionSchema.mjs').OptionSchema, oxlintPlugins: Set<string>, oxlintRules: Record<string, unknown>}} input Comparison input.
+ *
+ * @returns {Record<string, any[]>} The classified rules, each bucket sorted by
+ * canonical rule name.
+ */
+export function compare({
+  authored,
+  catalog,
+  eslintRules,
+  optionSchema,
+  oxlintPlugins,
+  oxlintRules,
+}) {
+  const configured = new Set(Object.keys(oxlintRules));
+  const eslintByCanonical = groupByCanonical(
+    eslintRules,
+    configured,
+    catalog.byName,
+  );
+
+  /** @type {any[]} */
+  const matched = [];
+  /** @type {any[]} */
+  const severityDiff = [];
+  /** @type {any[]} */
+  const missingInOxlint = [];
+  /** @type {any[]} */
+  const unsupported = [];
+  /** @type {any[]} */
+  const eslintIntentionallyOff = [];
+  /** @type {any[]} */
+  const optionsDiff = [];
+  /** @type {any[]} */
+  const bothOff = [];
+
+  for (const [canonical, eslintSide] of eslintByCanonical) {
+    const oxlintValue = oxlintRules[canonical];
+    const oxlintSeverity =
+      oxlintValue === undefined ? 'off' : severityOf(oxlintValue);
+    const entry = {
+      canonical,
+      eslintNames: eslintSide.eslintNames,
+      eslintSeverity: eslintSide.severity,
+      oxlintSeverity: oxlintValue === undefined ? 'unset' : oxlintSeverity,
+    };
+
+    if (eslintSide.severity === 'off') {
+      // oxlint enabling a rule ESLint deliberately disables produces reports the
+      // ESLint setup never had.
+      (oxlintSeverity === 'off' ? bothOff : eslintIntentionallyOff).push(entry);
+      continue;
+    }
+
+    if (oxlintSeverity === 'off') {
+      const catalogEntry = catalog.byName.get(canonical);
+
+      if (catalogEntry) {
+        missingInOxlint.push({
+          ...entry,
+          category: catalogEntry.category,
+          pluginEnabled:
+            catalogEntry.scope === '' || oxlintPlugins.has(catalogEntry.scope),
+          scope: catalogEntry.scope || 'eslint',
+          typeAware: catalogEntry.type_aware,
+        });
+      } else {
+        const { base, prefix } = splitRuleName(eslintSide.eslintNames[0]);
+
+        unsupported.push({
+          ...entry,
+          checkedCandidates: eslintSide.candidates,
+          plugin: prefix || 'eslint (core)',
+          // A same-named rule in another scope usually means the scope mapping
+          // needs an entry rather than that oxlint lacks the rule.
+          similar: (catalog.byBaseName.get(base) ?? []).filter(
+            (name) => name !== canonical,
+          ),
+        });
+      }
+
+      continue;
+    }
+
+    (oxlintSeverity === eslintSide.severity ? matched : severityDiff).push(
+      entry,
+    );
+
+    const difference = diffOptions(
+      canonical,
+      eslintSide.eslintNames,
+      authored,
+      optionSchema,
+    );
+
+    if (difference) {
+      optionsDiff.push({ ...entry, ...difference });
+    }
+  }
+
+  /** @type {any[]} */
+  const oxlintOnly = [];
+
+  for (const [rule, value] of Object.entries(oxlintRules)) {
+    if (eslintByCanonical.has(rule) || severityOf(value) === 'off') {
+      continue;
+    }
+
+    const catalogEntry = catalog.byName.get(rule);
+
+    oxlintOnly.push({
+      canonical: rule,
+      category: catalogEntry?.category ?? 'unknown',
+      oxlintSeverity: severityOf(value),
+      scope: catalogEntry?.scope || 'eslint',
+    });
+  }
+
+  /**
+   * @param {{canonical: string}} left A classified rule.
+   *
+   * @param {{canonical: string}} right Another classified rule.
+   *
+   * @returns {number} Their relative order by canonical name.
+   */
+  const byName = (left, right) => left.canonical.localeCompare(right.canonical);
+
+  return {
+    bothOff: bothOff.sort(byName),
+    eslintIntentionallyOff: eslintIntentionallyOff.sort(byName),
+    matched: matched.sort(byName),
+    missingInOxlint: missingInOxlint.sort(byName),
+    optionsDiff: optionsDiff.sort(byName),
+    oxlintOnly: oxlintOnly.sort(byName),
+    severityDiff: severityDiff.sort(byName),
+    unsupported: unsupported.sort(byName),
+  };
+}
+
+/**
+ * Compares the options both sides write for one rule.
+ *
+ * The snapshots are of no use here: ESLint's resolved config fills in schema
+ * defaults, and oxlint drops rule options from `--print-config`
+ * (https://github.com/oxc-project/oxc/issues/22230). Both sides therefore come
+ * from the configuration sources.
+ *
+ * @param {string} canonical The canonical oxlint rule name.
+ *
+ * @param {string[]} eslintNames Every ESLint rule mapping to `canonical`.
+ *
+ * @param {{eslint: Map<string, unknown[]> | null, oxlint: Map<string, unknown[]> | null}} authored Authored options per side.
+ *
+ * @param {import('./optionSchema.mjs').OptionSchema} optionSchema The loaded option schema.
+ *
+ * @returns {{eslintOptions: unknown[], notes: string[], oxlintOptions: unknown[], verdict: string} | null} The
+ * difference, or `null` when there is nothing to report.
+ */
+function diffOptions(canonical, eslintNames, authored, optionSchema) {
+  if (!authored.eslint || !authored.oxlint) {
+    return null;
+  }
+
+  const eslintOptions =
+    eslintNames
+      .map((name) => authored.eslint?.get(name))
+      .find((options) => options && options.length > 0) ?? [];
+  const oxlintOptions = authored.oxlint.get(canonical) ?? [];
+
+  if (eslintOptions.length === 0 && oxlintOptions.length === 0) {
+    return null;
+  }
+
+  if (stableStringify(eslintOptions) === stableStringify(oxlintOptions)) {
+    return null;
+  }
+
+  return {
+    ...judgeOptionDiff(canonical, eslintOptions, oxlintOptions, optionSchema),
+    eslintOptions,
+    oxlintOptions,
+  };
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/granularities.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/granularities.mjs
@@ -1,0 +1,87 @@
+// @ts-check
+
+import { ComparisonError } from './util.mjs';
+
+/**
+ * Maps a comparison granularity to the directory that holds each side's
+ * snapshot test. Paths are relative to the repository root.
+ *
+ * This table is the single source of truth for the granularity layout. Add an
+ * entry here when a new rule set gains a snapshot test.
+ *
+ * @type {Record<string, {eslintDir: string, oxlintDir: string}>}
+ */
+export const GRANULARITIES = {
+  essentials: {
+    eslintDir: 'packages/eslint-config/test/flat/essentials',
+    oxlintDir: 'packages/oxlint-config/src/configs/essentials',
+  },
+  typescript: {
+    eslintDir: 'packages/eslint-config/test/flat/typescript',
+    oxlintDir: 'packages/oxlint-config/src/configs/typescript',
+  },
+  nextjs: {
+    eslintDir: 'packages/eslint-config/test/flat/next',
+    oxlintDir: 'packages/oxlint-config/src/configs/nextjs',
+  },
+  node: {
+    eslintDir: 'packages/eslint-config/test/flat/node',
+    oxlintDir: 'packages/oxlint-config/src/configs/node',
+  },
+  react: {
+    eslintDir: 'packages/eslint-config/test/flat/react',
+    oxlintDir: 'packages/oxlint-config/src/configs/react',
+  },
+  storybook: {
+    eslintDir: 'packages/eslint-config/test/flat/storybook',
+    oxlintDir: 'packages/oxlint-config/src/configs/storybook',
+  },
+  'test.essentials': {
+    eslintDir: 'packages/eslint-config/test/flat/test/essentials',
+    oxlintDir: 'packages/oxlint-config/src/configs/test/essentials',
+  },
+  'test.react': {
+    eslintDir: 'packages/eslint-config/test/flat/test/react',
+    oxlintDir: 'packages/oxlint-config/src/configs/test/react',
+  },
+};
+
+/**
+ * Accepts the shorter names that appear in the ESLint side directory layout.
+ *
+ * @type {Record<string, string>}
+ */
+const GRANULARITY_ALIASES = {
+  next: 'nextjs',
+  ts: 'typescript',
+  'test-essentials': 'test.essentials',
+  'test-react': 'test.react',
+};
+
+/**
+ * @returns {string[]} Every granularity name, in declaration order.
+ */
+export function granularityNames() {
+  return Object.keys(GRANULARITIES);
+}
+
+/**
+ * @param {string | undefined} name A granularity name or alias.
+ *
+ * @returns {{eslintDir: string, granularity: string, oxlintDir: string}} The
+ * resolved granularity and its directories.
+ *
+ * @throws {ComparisonError} When the name is missing or unknown.
+ */
+export function resolveGranularity(name) {
+  const granularity = GRANULARITY_ALIASES[name ?? ''] ?? name;
+
+  if (!granularity || !GRANULARITIES[granularity]) {
+    throw new ComparisonError(
+      `粒度を指定してください。指定可能な粒度: ${granularityNames().join(', ')}`,
+      { showUsage: true },
+    );
+  }
+
+  return { granularity, ...GRANULARITIES[granularity] };
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/metadata.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/metadata.mjs
@@ -1,0 +1,75 @@
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { newestMtime } from './util.mjs';
+
+/**
+ * Warns when a snapshot file is older than the configuration it captures, which
+ * means the snapshot test has not been re-run since the last edit.
+ *
+ * @param {{eslintDirAbs: string, eslintSnapshot: string, oxlintDirAbs: string, oxlintSnapshot: string, repoRoot: string}} input Paths to inspect.
+ *
+ * @returns {string[]} Warning messages.
+ */
+export function collectWarnings({
+  eslintDirAbs,
+  eslintSnapshot,
+  oxlintDirAbs,
+  oxlintSnapshot,
+  repoRoot,
+}) {
+  const sides = [
+    {
+      label: 'ESLint',
+      snapshot: eslintSnapshot,
+      sources: [
+        path.join(eslintDirAbs, 'eslint.config.mjs'),
+        path.join(repoRoot, 'packages/eslint-config/configs'),
+        path.join(repoRoot, 'packages/eslint-config/rules'),
+      ],
+    },
+    {
+      label: 'oxlint',
+      snapshot: oxlintSnapshot,
+      sources: [
+        path.join(oxlintDirAbs, 'oxlint.config.ts'),
+        path.join(repoRoot, 'packages/oxlint-config/src'),
+      ],
+    },
+  ];
+
+  return sides
+    .filter(
+      (side) =>
+        Math.max(...side.sources.map(newestMtime)) >
+        fs.statSync(side.snapshot).mtimeMs,
+    )
+    .map(
+      (side) =>
+        `${side.label} 側の snapshot (\`${path.relative(repoRoot, side.snapshot)}\`) が設定ソースより古いため、snapshot テストの再実行が必要な可能性があります。`,
+    );
+}
+
+/**
+ * Extracts the rule set composition from a config file so the report can show
+ * whether both sides compose corresponding presets.
+ *
+ * @param {string} file Absolute path to a config file.
+ *
+ * @param {RegExp} pattern Pattern whose first capture group holds the composition.
+ *
+ * @returns {string} A single line description, or a fallback message.
+ */
+export function readComposition(file, pattern) {
+  if (!fs.existsSync(file)) {
+    return '(ファイルなし)';
+  }
+
+  const matched = pattern.exec(fs.readFileSync(file, 'utf8'));
+
+  return matched
+    ? matched[1].replace(/\s+/g, ' ').replace(/,\s*\]/, ']')
+    : '(取得不可)';
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/optionSchema.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/optionSchema.mjs
@@ -1,0 +1,183 @@
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { stableStringify } from './util.mjs';
+
+/**
+ * @typedef {{resolve: (node: any) => any, slotsOf: (rule: string) => any[] | null}} OptionSchema
+ */
+
+/**
+ * Loads oxlint's JSON schema, which documents each rule's option shape and the
+ * default value of every option. This is what makes it possible to tell an
+ * option oxlint deliberately omits (because the value equals its default) from
+ * one that is genuinely missing.
+ *
+ * @param {string} repoRoot Absolute path to the repository root.
+ *
+ * @returns {OptionSchema} A lookup for a rule's positional option schemas,
+ * excluding the leading severity slot. Every rule reports `null` when the schema
+ * is unavailable.
+ */
+export function loadOptionSchema(repoRoot) {
+  const file = path.join(
+    repoRoot,
+    'packages/oxlint-config/node_modules/oxlint/configuration_schema.json',
+  );
+
+  if (!fs.existsSync(file)) {
+    return { resolve: (node) => node, slotsOf: () => null };
+  }
+
+  const definitions =
+    JSON.parse(fs.readFileSync(file, 'utf8')).definitions ?? {};
+
+  /**
+   * @param {any} node A schema node that may be a `$ref`.
+   *
+   * @returns {any} The resolved node.
+   */
+  const resolve = (node) => {
+    let current = node;
+
+    for (let depth = 0; current?.$ref && depth < 10; depth += 1) {
+      current = definitions[current.$ref.split('/').pop()];
+    }
+
+    return current ?? {};
+  };
+
+  // `OxlintRules` is itself a chain of `$ref`s ending in the map that holds one
+  // property per rule.
+  const properties = resolve(definitions.OxlintRules)?.properties ?? {};
+
+  return {
+    resolve,
+    slotsOf(rule) {
+      const tuple = properties[rule]?.anyOf?.find(
+        (variant) => variant.type === 'array' && Array.isArray(variant.items),
+      );
+
+      return tuple ? tuple.items.slice(1).map(resolve) : null;
+    },
+  };
+}
+
+/**
+ * Decides whether an option difference is real, by resolving oxlint's effective
+ * value for every option: the value the rule set writes when present, otherwise
+ * the default declared in oxlint's schema.
+ *
+ * @param {string} rule The oxlint rule name.
+ *
+ * @param {unknown[]} eslintOptions Options authored on the ESLint side.
+ *
+ * @param {unknown[]} oxlintOptions Options authored on the oxlint side.
+ *
+ * @param {OptionSchema} schema The loaded option schema.
+ *
+ * @returns {{notes: string[], verdict: 'differs' | 'equivalent' | 'unknown'}} `differs`
+ * when the effective values disagree, `equivalent` when oxlint merely omits a
+ * value equal to its default, and `unknown` when the schema does not declare
+ * enough to decide.
+ */
+export function judgeOptionDiff(rule, eslintOptions, oxlintOptions, schema) {
+  const slots = schema.slotsOf(rule);
+
+  if (!slots) {
+    return {
+      notes: ['oxlint のスキーマにこのルールのオプション定義がない'],
+      verdict: 'unknown',
+    };
+  }
+
+  const notes = [];
+  let unknown = false;
+
+  eslintOptions.forEach((expected, index) => {
+    const slot = slots[index];
+    const authored = oxlintOptions[index];
+
+    if (!slot) {
+      notes.push(`位置 ${index}: oxlint に対応するオプションがない`);
+
+      return;
+    }
+
+    if (isPlainObject(expected)) {
+      for (const [key, value] of Object.entries(expected)) {
+        const property = slot.properties?.[key];
+
+        if (!property) {
+          notes.push(`\`${key}\`: oxlint に該当オプションがない`);
+          continue;
+        }
+
+        const fallback = defaultOf(property, schema);
+        const effective =
+          isPlainObject(authored) && key in authored ? authored[key] : fallback;
+
+        if (effective === undefined) {
+          unknown = true;
+          notes.push(`\`${key}\`: oxlint の既定値がスキーマに無く判定不能`);
+          continue;
+        }
+
+        if (stableStringify(effective) !== stableStringify(value)) {
+          notes.push(
+            `\`${key}\`: ESLint=${JSON.stringify(value)} / oxlint=${JSON.stringify(effective)}`,
+          );
+        }
+      }
+
+      return;
+    }
+
+    const effective = authored === undefined ? slot.default : authored;
+
+    if (effective === undefined) {
+      unknown = true;
+      notes.push(
+        `位置 ${index}: oxlint の既定値がスキーマに無く判定不能（ESLint=${JSON.stringify(expected)}）`,
+      );
+
+      return;
+    }
+
+    if (stableStringify(effective) !== stableStringify(expected)) {
+      notes.push(
+        `位置 ${index}: ESLint=${JSON.stringify(expected)} / oxlint=${JSON.stringify(effective)}`,
+      );
+    }
+  });
+
+  if (notes.length === 0) {
+    return { notes, verdict: 'equivalent' };
+  }
+
+  return { notes, verdict: unknown ? 'unknown' : 'differs' };
+}
+
+/**
+ * @param {any} property A schema property node.
+ *
+ * @param {OptionSchema} schema The loaded option schema, used to follow `$ref`s.
+ *
+ * @returns {unknown} The declared default, or `undefined` when there is none.
+ */
+function defaultOf(property, schema) {
+  return 'default' in property
+    ? property.default
+    : schema.resolve(property).default;
+}
+
+/**
+ * @param {unknown} value A value to test.
+ *
+ * @returns {boolean} `true` for an option object, `false` for arrays and scalars.
+ */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/report.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/report.mjs
@@ -1,0 +1,309 @@
+// @ts-check
+
+import { truncate } from './util.mjs';
+
+/**
+ * Renders the comparison as the Markdown report that gets saved under
+ * `packages/oxlint-config/docs/mapping/`.
+ *
+ * @param {Record<string, any>} meta Report metadata.
+ *
+ * @param {Record<string, any[]>} result Classified rules.
+ *
+ * @param {{verbose: boolean}} options Rendering options.
+ *
+ * @returns {string} The Markdown report.
+ */
+export function renderMarkdown(meta, result, options) {
+  return `${[
+    `# ルールマッピング比較: ${meta.granularity}`,
+    '',
+    ...targetSection(meta),
+    ...summarySection(result),
+    ...ruleSections(result),
+    ...optionSections(meta, result),
+    ...matchedSection(result, options),
+  ].join('\n')}\n`;
+}
+
+/**
+ * @param {Record<string, any>} meta Report metadata.
+ *
+ * @returns {string[]} The rendered lines.
+ */
+function targetSection(meta) {
+  const lines = [
+    '## 対象',
+    '',
+    `- ESLint snapshot: \`${meta.eslintSnapshot}\`（${meta.eslintRuleCount} ルール）`,
+    `- oxlint snapshot: \`${meta.oxlintSnapshot}\`（${meta.oxlintRuleCount} ルール）`,
+    `- ESLint 側構成: \`${meta.eslintComposition}\``,
+    `- oxlint 側構成: \`extends: ${meta.oxlintComposition}\``,
+    `- oxlint 有効プラグイン: ${
+      meta.oxlintPlugins.length > 0
+        ? meta.oxlintPlugins.map((name) => `\`${name}\``).join(', ')
+        : '(なし)'
+    }`,
+    '',
+  ];
+
+  if (meta.warnings.length > 0) {
+    lines.push(
+      '> [!WARNING]',
+      ...meta.warnings.map((warning) => `> ${warning}`),
+      '',
+    );
+  }
+
+  return lines;
+}
+
+/**
+ * @param {Record<string, any[]>} result Classified rules.
+ *
+ * @returns {string[]} The rendered lines.
+ */
+function summarySection(result) {
+  const byVerdict = (verdict) =>
+    result.optionsDiff.filter((entry) => entry.verdict === verdict).length;
+
+  return [
+    '## サマリ',
+    '',
+    '| 区分 | 件数 |',
+    '| --- | --- |',
+    `| ✅ マッピング済み | ${result.matched.length} |`,
+    `| ❌ oxlint 側で未設定（oxlint はサポート済み） | ${result.missingInOxlint.length} |`,
+    `| 🚫 oxlint 未サポート | ${result.unsupported.length} |`,
+    `| ⚠️ 重大度の相違 | ${result.severityDiff.length} |`,
+    `| ➕ oxlint 側のみ有効 | ${result.oxlintOnly.length} |`,
+    `| ➕ ESLint で off だが oxlint で有効 | ${result.eslintIntentionallyOff.length} |`,
+    `| オプション差異 | ${result.optionsDiff.length}（要対応 ${byVerdict('differs')} / 判定不能 ${byVerdict('unknown')} / 実質一致 ${byVerdict('equivalent')}） |`,
+    `| 両側とも無効 | ${result.bothOff.length} |`,
+    '',
+  ];
+}
+
+/**
+ * @param {Record<string, any[]>} result Classified rules.
+ *
+ * @returns {string[]} The rendered lines.
+ */
+function ruleSections(result) {
+  return [
+    ...section(
+      '## ❌ oxlint 側で未設定（oxlint はサポート済み → 要対応）',
+      result.missingInOxlint,
+      [
+        'ESLint ルール',
+        'oxlint ルール',
+        'ESLint 重大度',
+        'category',
+        'type-aware',
+        'plugin',
+      ],
+      (entry) => [
+        ruleList(entry.eslintNames),
+        `\`${entry.canonical}\``,
+        entry.eslintSeverity,
+        entry.category,
+        entry.typeAware ? 'yes' : 'no',
+        entry.pluginEnabled ? '有効' : `**未有効 (${entry.scope})**`,
+      ],
+    ),
+    ...unsupportedSection(result.unsupported),
+    ...section(
+      '## ⚠️ 重大度の相違',
+      result.severityDiff,
+      ['ESLint ルール', 'oxlint ルール', 'ESLint', 'oxlint'],
+      (entry) => [
+        ruleList(entry.eslintNames),
+        `\`${entry.canonical}\``,
+        entry.eslintSeverity,
+        entry.oxlintSeverity,
+      ],
+    ),
+    ...section(
+      '## ➕ ESLint で意図的に off だが oxlint で有効（過剰の可能性）',
+      result.eslintIntentionallyOff,
+      ['ESLint ルール', 'oxlint ルール', 'oxlint 重大度'],
+      (entry) => [
+        ruleList(entry.eslintNames),
+        `\`${entry.canonical}\``,
+        entry.oxlintSeverity,
+      ],
+    ),
+    ...section(
+      '## ➕ oxlint 側のみ有効（ESLint に対応ルールなし）',
+      result.oxlintOnly,
+      ['oxlint ルール', 'scope', 'category', '重大度'],
+      (entry) => [
+        `\`${entry.canonical}\``,
+        entry.scope,
+        entry.category,
+        entry.oxlintSeverity,
+      ],
+    ),
+  ];
+}
+
+/**
+ * Groups the unsupported rules by ESLint plugin, because a whole plugin missing
+ * from oxlint reads very differently from a single rule missing.
+ *
+ * @param {any[]} unsupported The unsupported rules.
+ *
+ * @returns {string[]} The rendered lines.
+ */
+function unsupportedSection(unsupported) {
+  const lines = ['## 🚫 oxlint 未サポート（やむを得ない差分）', ''];
+
+  if (unsupported.length === 0) {
+    return [...lines, '該当なし。', ''];
+  }
+
+  /** @type {Map<string, any[]>} */
+  const groups = new Map();
+
+  for (const entry of unsupported) {
+    groups.set(entry.plugin, [...(groups.get(entry.plugin) ?? []), entry]);
+  }
+
+  for (const [plugin, entries] of [...groups].sort((left, right) =>
+    left[0].localeCompare(right[0]),
+  )) {
+    lines.push(
+      ...section(
+        `### ${plugin}（${entries.length} 件）`,
+        entries,
+        ['ESLint ルール', 'ESLint 重大度', '類似候補'],
+        (entry) => [
+          ruleList(entry.eslintNames),
+          entry.eslintSeverity,
+          entry.similar.length > 0 ? ruleList(entry.similar) : '-',
+        ],
+      ),
+    );
+  }
+
+  return lines;
+}
+
+/**
+ * Renders the option comparison, split by how conclusive each difference is.
+ *
+ * @param {Record<string, any>} meta Report metadata.
+ *
+ * @param {Record<string, any[]>} result Classified rules.
+ *
+ * @returns {string[]} The rendered lines.
+ */
+function optionSections(meta, result) {
+  const lines = ['## オプション指定の差異', ''];
+
+  if (meta.authoredOptionsErrors.length > 0) {
+    return [
+      ...lines,
+      `設定ソースを読み込めなかったため判定できません（${meta.authoredOptionsErrors.join(' / ')}）。`,
+      '',
+    ];
+  }
+
+  const byVerdict = (verdict) =>
+    result.optionsDiff.filter((entry) => entry.verdict === verdict);
+  const toRow = (entry) => [
+    `\`${entry.canonical}\``,
+    `\`${truncate(JSON.stringify(entry.eslintOptions), 70)}\``,
+    entry.notes.join('<br>'),
+  ];
+  const equivalent = byVerdict('equivalent');
+
+  return [
+    ...lines,
+    'オプションは snapshot ではなく両側の設定ソース（`eslint.config.mjs` / `oxlint.config.ts`）から読み取り、oxlint 側の実効値は「rule set に書かれた値、無ければ `configuration_schema.json` の既定値」として突き合わせています。ESLint の解決済み設定はスキーマ既定値も埋めてしまい、oxlint は object 形式の `extends` を使うと `--print-config` からオプションを落とすため（[oxc#22230](https://github.com/oxc-project/oxc/issues/22230)、実行時の挙動には影響しない）、いずれの snapshot からも実際の指定は判定できません。',
+    '',
+    ...section(
+      '### 要対応: 実効値が異なる',
+      byVerdict('differs'),
+      ['ルール', 'ESLint options', '差分'],
+      toRow,
+    ),
+    ...section(
+      '### 判定不能: oxlint の既定値が不明',
+      byVerdict('unknown'),
+      ['ルール', 'ESLint options', '理由'],
+      toRow,
+      'oxlint のドキュメントで既定値を確認する必要があります。',
+    ),
+    `### 実質一致: oxlint の既定値と同じ（${equivalent.length} 件）`,
+    '',
+    equivalent.length > 0
+      ? `対応不要です: ${ruleList(equivalent.map((entry) => entry.canonical))}`
+      : '該当なし。',
+    '',
+  ];
+}
+
+/**
+ * @param {Record<string, any[]>} result Classified rules.
+ *
+ * @param {{verbose: boolean}} options Rendering options.
+ *
+ * @returns {string[]} The rendered lines.
+ */
+function matchedSection(result, options) {
+  const lines = [`## ✅ マッピング済み（${result.matched.length} 件）`, ''];
+
+  if (!options.verbose) {
+    return [...lines, '`--verbose` を付けると一覧を出力します。', ''];
+  }
+
+  return [
+    ...lines,
+    '| ESLint ルール | oxlint ルール | 重大度 |',
+    '| --- | --- | --- |',
+    ...result.matched.map(
+      (entry) =>
+        `| ${ruleList(entry.eslintNames)} | \`${entry.canonical}\` | ${entry.eslintSeverity} |`,
+    ),
+    '',
+  ];
+}
+
+/**
+ * @param {string} heading The section heading.
+ *
+ * @param {any[]} entries The rows to render.
+ *
+ * @param {string[]} headers Table headers.
+ *
+ * @param {(entry: any) => string[]} toCells Maps an entry to table cells.
+ *
+ * @param {string} [note] An optional note rendered under the heading.
+ *
+ * @returns {string[]} The rendered lines.
+ */
+function section(heading, entries, headers, toCells, note) {
+  const lines = [heading, '', ...(note ? [note, ''] : [])];
+
+  if (entries.length === 0) {
+    return [...lines, '該当なし。', ''];
+  }
+
+  return [
+    ...lines,
+    `| ${headers.join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+    ...entries.map((entry) => `| ${toCells(entry).join(' | ')} |`),
+    '',
+  ];
+}
+
+/**
+ * @param {string[]} rules Rule names.
+ *
+ * @returns {string} The names as an inline code list.
+ */
+function ruleList(rules) {
+  return rules.map((rule) => `\`${rule}\``).join(', ');
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/ruleName.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/ruleName.mjs
@@ -1,0 +1,93 @@
+// @ts-check
+
+/**
+ * Maps an ESLint plugin prefix to the oxlint scopes that may provide the
+ * equivalent rule, in priority order. An empty string means oxlint's `eslint`
+ * scope, which carries no prefix in configuration files. An empty array means
+ * oxlint has no scope covering the plugin at all.
+ *
+ * This table is the single source of truth for prefix mapping. Extend it here
+ * when oxlint gains a new plugin scope.
+ *
+ * @type {Record<string, string[]>}
+ */
+const SCOPE_MAP = {
+  '': [''],
+  '@next/next': ['nextjs'],
+  '@typescript-eslint': ['typescript', ''],
+  import: ['import'],
+  jest: ['jest', 'vitest'],
+  'jest-dom': [],
+  jsdoc: ['jsdoc'],
+  'jsx-a11y': ['jsx-a11y'],
+  n: ['node'],
+  node: ['node'],
+  promise: ['promise'],
+  react: ['react', 'react-perf'],
+  'react-hooks': ['react'],
+  storybook: [],
+  'testing-library': [],
+  unicorn: ['unicorn'],
+  vitest: ['vitest', 'jest'],
+};
+
+/**
+ * @param {string} rule An ESLint rule name.
+ *
+ * @returns {{base: string, prefix: string}} The plugin prefix and bare rule name.
+ */
+export function splitRuleName(rule) {
+  const segments = rule.split('/');
+
+  if (rule.startsWith('@')) {
+    return segments.length > 2
+      ? {
+          base: segments.slice(2).join('/'),
+          prefix: segments.slice(0, 2).join('/'),
+        }
+      : { base: segments[1] ?? '', prefix: segments[0] };
+  }
+
+  return segments.length > 1
+    ? { base: segments.slice(1).join('/'), prefix: segments[0] }
+    : { base: rule, prefix: '' };
+}
+
+/**
+ * Resolves the oxlint configuration name that corresponds to an ESLint rule.
+ *
+ * Several oxlint scopes can plausibly host the same rule (`react-hooks/*` lives
+ * in oxlint's `react` scope, jest rules also exist under `vitest`), so the
+ * candidates are tried against the resolved oxlint config first, then against
+ * the catalog, before falling back to the highest priority candidate.
+ *
+ * @param {string} rule An ESLint rule name.
+ *
+ * @param {Set<string>} configured Rule names present in the oxlint config.
+ *
+ * @param {Map<string, unknown>} catalogByName The oxlint rule catalog.
+ *
+ * @returns {{candidates: string[], name: string}} The canonical oxlint name and
+ * every candidate that was considered.
+ */
+export function canonicalize(rule, configured, catalogByName) {
+  const { base, prefix } = splitRuleName(rule);
+  const scopes = SCOPE_MAP[prefix] ?? [prefix];
+  const candidates = scopes.map((scope) => (scope ? `${scope}/${base}` : base));
+
+  // A plugin oxlint has no scope for still needs a name to report.
+  if (candidates.length === 0) {
+    candidates.push(rule);
+  }
+
+  // oxlint keeps some ported rules in its own `oxc` scope.
+  candidates.push(`oxc/${base}`);
+
+  const unique = [...new Set(candidates)];
+  const resolved =
+    unique.find((candidate) => configured.has(candidate)) ??
+    unique.find((candidate) => catalogByName.has(candidate)) ??
+    unique[0];
+
+  return { candidates: unique, name: resolved };
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/snapshot.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/snapshot.mjs
@@ -1,0 +1,302 @@
+// @ts-check
+
+/**
+ * Reads values out of Vitest snapshot files.
+ *
+ * Vitest serialises snapshots with `pretty-format`, which does not escape double
+ * quotes inside strings (for example `"input[type="image"]"`), so a snapshot body
+ * is not valid JSON. The parser here relies on `pretty-format`'s deterministic
+ * layout instead — two space indentation, trailing commas, one value per line —
+ * and never evaluates the file.
+ */
+
+import fs from 'node:fs';
+
+import { ComparisonError } from './util.mjs';
+
+/**
+ * Reads one or more top-level sections out of a Vitest snapshot file.
+ *
+ * @param {string} file Absolute path to a `*.snap` file.
+ *
+ * @param {string} label Human readable side name used in error messages.
+ *
+ * @param {string[]} keys Top-level keys to extract. A key that is absent yields
+ * `undefined`, except `rules`, whose absence means the snapshot is unusable.
+ *
+ * @returns {Record<string, any>} The extracted sections, keyed by `keys`.
+ */
+export function readSections(file, label, keys) {
+  const body = extractSnapshotBody(file, label);
+  /** @type {Record<string, any>} */
+  const sections = {};
+
+  for (const key of keys) {
+    // Anchored to the root object's two space indentation so that a nested
+    // `rules` block (oxlint's `overrides[]`, ESLint's `settings`) is not picked
+    // up instead of the resolved top-level one.
+    const start = body.findIndex((line) =>
+      new RegExp(`^ {2}"${escapeRegExp(key)}": [[{]$`).test(line),
+    );
+
+    if (start < 0) {
+      if (key === 'rules') {
+        throw new ComparisonError(
+          `${label} 側 snapshot に "rules" セクションが見つかりません: ${file}`,
+        );
+      }
+
+      sections[key] = undefined;
+      continue;
+    }
+
+    sections[key] = parseContainer(body, start, file, label).value;
+  }
+
+  return sections;
+}
+
+/**
+ * Extracts the serialised body of the first snapshot entry in a `*.snap` file
+ * and undoes the template literal escaping Vitest applies when writing it.
+ *
+ * @param {string} file Absolute path to a `*.snap` file.
+ *
+ * @param {string} label Human readable side name used in error messages.
+ *
+ * @returns {string[]} The snapshot body, line by line.
+ */
+function extractSnapshotBody(file, label) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const inline = /^exports\[`.*`\] = `(.*)`;$/.exec(lines[index]);
+
+    if (inline) {
+      throw new ComparisonError(
+        [
+          `${label} 側 snapshot の値が \`${inline[1]}\` になっています: ${file}`,
+          'snapshot テストが設定を解決できていない可能性があります（対象ファイルパスが config の files パターンに一致していない等）。テスト側を修正してから再実行してください。',
+        ].join('\n'),
+      );
+    }
+
+    if (!/^exports\[`.*`\] = `$/.test(lines[index])) {
+      continue;
+    }
+
+    const body = [];
+
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (lines[cursor] === '`;') {
+        return body;
+      }
+
+      body.push(unescapeSnapshotLine(lines[cursor]));
+    }
+  }
+
+  throw new ComparisonError(
+    `${label} 側 snapshot エントリを解析できませんでした: ${file}`,
+  );
+}
+
+/**
+ * Reverses Vitest's `escapeBacktickString`, which prefixes a backslash to
+ * backticks, backslashes, and `${`.
+ *
+ * @param {string} line A raw snapshot line.
+ *
+ * @returns {string} The unescaped line.
+ */
+function unescapeSnapshotLine(line) {
+  return line.replace(/\\(.)/g, '$1');
+}
+
+/**
+ * Parses the object or array that starts on `body[start]`.
+ *
+ * @param {string[]} body The snapshot body.
+ *
+ * @param {number} start Index of the line that opens the container.
+ *
+ * @param {string} file Snapshot path, used in error messages.
+ *
+ * @param {string} label Human readable side name used in error messages.
+ *
+ * @returns {{next: number, value: any}} The parsed container and the index of
+ * the line after it.
+ */
+function parseContainer(body, start, file, label) {
+  const opener = body[start].trimEnd().slice(-1);
+
+  return opener === '['
+    ? parseArray(body, start + 1, file, label)
+    : parseObject(body, start + 1, file, label);
+}
+
+/**
+ * @param {string[]} body The snapshot body.
+ *
+ * @param {number} start Index of the first line inside the object.
+ *
+ * @param {string} file Snapshot path, used in error messages.
+ *
+ * @param {string} label Human readable side name used in error messages.
+ *
+ * @returns {{next: number, value: Record<string, any>}} The parsed object.
+ */
+function parseObject(body, start, file, label) {
+  /** @type {Record<string, any>} */
+  const value = {};
+  let cursor = start;
+
+  while (cursor < body.length) {
+    const trimmed = body[cursor].trim();
+
+    if (trimmed === '}' || trimmed === '},') {
+      return { next: cursor + 1, value };
+    }
+
+    // The key is delimited by the *last* `": ` on the line, because
+    // `pretty-format` leaves quotes inside keys unescaped.
+    const entry = /^\s*"(.*)": (.*)$/.exec(body[cursor]);
+
+    if (!entry) {
+      throw new ComparisonError(
+        `${label} 側 snapshot の ${cursor + 1} 行目を解析できませんでした: ${file}\n  ${body[cursor]}`,
+      );
+    }
+
+    const [, key, rest] = entry;
+
+    if (rest === '{' || rest === '[') {
+      const parsed = parseContainer(body, cursor, file, label);
+
+      value[key] = parsed.value;
+      cursor = parsed.next;
+      continue;
+    }
+
+    const scalar = parseScalar(body, cursor);
+
+    value[key] = scalar.value;
+    cursor = scalar.next;
+  }
+
+  throw new ComparisonError(
+    `${label} 側 snapshot のオブジェクトが閉じられていません: ${file}`,
+  );
+}
+
+/**
+ * @param {string[]} body The snapshot body.
+ *
+ * @param {number} start Index of the first line inside the array.
+ *
+ * @param {string} file Snapshot path, used in error messages.
+ *
+ * @param {string} label Human readable side name used in error messages.
+ *
+ * @returns {{next: number, value: any[]}} The parsed array.
+ */
+function parseArray(body, start, file, label) {
+  /** @type {any[]} */
+  const value = [];
+  let cursor = start;
+
+  while (cursor < body.length) {
+    const trimmed = body[cursor].trim();
+
+    if (trimmed === ']' || trimmed === '],') {
+      return { next: cursor + 1, value };
+    }
+
+    if (trimmed === '{' || trimmed === '[') {
+      const parsed = parseContainer(body, cursor, file, label);
+
+      value.push(parsed.value);
+      cursor = parsed.next;
+      continue;
+    }
+
+    const scalar = parseScalar(body, cursor);
+
+    value.push(scalar.value);
+    cursor = scalar.next;
+  }
+
+  throw new ComparisonError(
+    `${label} 側 snapshot の配列が閉じられていません: ${file}`,
+  );
+}
+
+/**
+ * Parses a scalar value, joining continuation lines when `pretty-format` printed
+ * a string that contains newlines.
+ *
+ * @param {string[]} body The snapshot body.
+ *
+ * @param {number} start Index of the line that holds the value.
+ *
+ * @returns {{next: number, value: unknown}} The parsed value.
+ */
+function parseScalar(body, start) {
+  const entry = /^\s*"(?:.*)": (.*)$/.exec(body[start]);
+  let raw = entry ? entry[1] : body[start].trim();
+  let cursor = start;
+
+  while (isUnterminatedString(raw) && cursor + 1 < body.length) {
+    cursor += 1;
+    raw = `${raw}\n${body[cursor]}`;
+  }
+
+  const trimmedRaw = raw.endsWith(',') ? raw.slice(0, -1) : raw;
+
+  if (trimmedRaw.startsWith('"') && trimmedRaw.endsWith('"')) {
+    return { next: cursor + 1, value: trimmedRaw.slice(1, -1) };
+  }
+
+  if (trimmedRaw === 'true' || trimmedRaw === 'false') {
+    return { next: cursor + 1, value: trimmedRaw === 'true' };
+  }
+
+  if (
+    trimmedRaw === 'null' ||
+    trimmedRaw === 'undefined' ||
+    trimmedRaw === '[Function anonymous]'
+  ) {
+    return { next: cursor + 1, value: null };
+  }
+
+  if (trimmedRaw === '{}' || trimmedRaw === '[]') {
+    return { next: cursor + 1, value: trimmedRaw === '{}' ? {} : [] };
+  }
+
+  if (/^-?\d+(?:\.\d+)?(?:e[+-]?\d+)?$/i.test(trimmedRaw)) {
+    return { next: cursor + 1, value: Number(trimmedRaw) };
+  }
+
+  return { next: cursor + 1, value: trimmedRaw };
+}
+
+/**
+ * Detects a value that `pretty-format` printed as a string containing newlines,
+ * which spans several snapshot lines.
+ *
+ * @param {string} raw The raw value collected so far.
+ *
+ * @returns {boolean} `true` while the closing quote has not been reached.
+ */
+function isUnterminatedString(raw) {
+  return raw.startsWith('"') && !(raw.length > 1 && /"[,]?$/.test(raw));
+}
+
+/**
+ * @param {string} value A literal to embed in a regular expression.
+ *
+ * @returns {string} The escaped literal.
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/util.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/util.mjs
@@ -1,0 +1,85 @@
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Signals a condition the user has to resolve (a missing snapshot, an
+ * unparsable file, a missing oxlint binary). The CLI turns this into a message
+ * on stderr and a non-zero exit code, so nothing below the CLI layer needs to
+ * call `process.exit`.
+ */
+export class ComparisonError extends Error {
+  /**
+   * @param {string} message The message shown to the user.
+   *
+   * @param {{showUsage?: boolean}} [options] Set `showUsage` when the message is
+   * about how the command was invoked, so the CLI appends its usage text.
+   */
+  constructor(message, options = {}) {
+    super(message);
+    this.name = 'ComparisonError';
+    this.showUsage = options.showUsage ?? false;
+  }
+}
+
+/**
+ * Serialises a value with object keys sorted, so that two option objects that
+ * differ only in property order compare as equal.
+ *
+ * @param {unknown} value The value to serialise.
+ *
+ * @returns {string} A key-order independent JSON string.
+ */
+export function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value) ?? 'null';
+}
+
+/**
+ * @param {string} value A value to shorten for table display.
+ *
+ * @param {number} [max] The maximum length.
+ *
+ * @returns {string} The shortened value.
+ */
+export function truncate(value, max = 120) {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+/**
+ * @param {string} target A file or directory path.
+ *
+ * @returns {number} The newest modification time in milliseconds, or 0 when the
+ * path does not exist.
+ */
+export function newestMtime(target) {
+  if (!fs.existsSync(target)) {
+    return 0;
+  }
+
+  const stats = fs.statSync(target);
+
+  if (!stats.isDirectory()) {
+    return stats.mtimeMs;
+  }
+
+  return fs
+    .readdirSync(target)
+    .filter((entry) => entry !== 'node_modules' && entry !== '__snapshots__')
+    .reduce(
+      (newest, entry) =>
+        Math.max(newest, newestMtime(path.join(target, entry))),
+      stats.mtimeMs,
+    );
+}


### PR DESCRIPTION
## What changed / motivation ?

Adds a Claude Code skill (`.claude/skills/compare-lint-rules/`) and a thin slash command (`.claude/commands/compare-lint-rules.md`) that compare the rule sets of `eslint-config-moneyforward` and `oxlint-config-moneyforward` for one granularity at a time.

`oxlint-config-moneyforward` re-implements `eslint-config-moneyforward` on top of oxlint, so its rules must map to the ESLint ones unless oxlint cannot support them. Verifying that means diffing both snapshot test results repeatedly, once per granularity (`essentials` / `typescript` / `nextjs` / `node` / `react` / `storybook` / `test.essentials` / `test.react`). This packages that procedure so the same long instructions do not have to be written each time.

Running `/compare-lint-rules <granularity>` classifies every rule into: mapped, missing on the oxlint side although oxlint supports it, not supported by oxlint, severity mismatch, enabled only on the oxlint side, and option differences. The report is written to `packages/oxlint-config/docs/mapping/<granularity>.md`.

Notes on how the comparison works, since the naive approach does not:

- **Severities come from the committed Vitest snapshots**, which already have file scoping resolved. Vitest serialises snapshots with `pretty-format`, which leaves quotes inside strings unescaped (for example `input[type="image"]`), so they are not valid JSON. A line oriented parser relies on `pretty-format`'s deterministic layout; nothing is `eval`ed.
- **Options cannot come from either snapshot.** ESLint's resolved config fills in every rule's schema defaults, and oxlint drops rule options from `--print-config` when object-form `extends` is used ([oxc-project/oxc#22230](https://github.com/oxc-project/oxc/issues/22230); runtime behaviour is unaffected). Both sides are therefore read from `eslint.config.mjs` / `oxlint.config.ts`.
- **Whether oxlint supports a rule at all** is decided by `oxlint --rules -f json`, and **whether an omitted option matters** is decided by the option defaults in `node_modules/oxlint/configuration_schema.json`. Options that oxlint intentionally omits because they equal its defaults are reported as equivalent rather than as gaps.

Scope of this PR is `.claude/` only. The `oxlint-config` rule sets still under development and the generated mapping reports are intentionally left out.

## Linked PR / Issues

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

Nothing under `packages/` changes: this only adds developer tooling used through Claude Code.

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- [oxc-project/oxc#22230 - rule options are dropped from `--print-config` when using object-form `extends`](https://github.com/oxc-project/oxc/issues/22230)
