### PR TITLE
fix(claude): resolve oxlint overrides in compare-lint-rules

### DIFF
--- a/.claude/skills/compare-lint-rules/SKILL.md
+++ b/.claude/skills/compare-lint-rules/SKILL.md
@@ -9,14 +9,14 @@ description: Compares the snapshot test results of eslint-config-moneyforward an
 
 ## Prerequisites
 
-This skill does not run the snapshot tests. It reads the **committed `.snap` files**, so the snapshot test for the target granularity must have been run beforehand. If it has not, point at these commands:
+The comparison itself reads the **committed `.snap` files**, so the snapshot test for the target granularity must have been run beforehand. If it has not, point at these commands (running them to verify a freshness warning is fine; **creating** a snapshot test is out of scope):
 
 ```bash
 pnpm eslint-config test run test/flat/<dir>     # ESLint side
 pnpm oxlint-config test run src/configs/<dir>   # oxlint side
 ```
 
-The script warns when a snapshot is older than the configuration it captures. When that warning appears, ask for the test to be re-run and state that the comparison is provisional.
+The script warns when a snapshot is older than the configuration it captures. The check only compares mtimes, so it fires on checkout order and on unrelated edits under the same tree — **it is often a false positive**. When the warning appears, run the two commands above yourself: a passing test means the snapshot matches the current configuration, and the report should say the warning was verified as a false positive rather than repeat it. Only when a test actually fails is the comparison provisional.
 
 ## Granularities and directories
 
@@ -68,9 +68,11 @@ Do not report the script's mechanical classification as-is. Always check the fol
 
    When a rule turns out to have merely been renamed or moved to another scope, propose adding it to `SCOPE_MAP` in `scripts/lib/ruleName.mjs` and re-running.
 
-3. **The plugin column under ❌ (unset on the oxlint side).** A row marked `未有効 (<scope>)` means the plugin is not enabled, so writing the rule alone would have no effect. Point out that the oxlint config's `plugins` may be incomplete.
+3. **That the `overrides` merge covered the rules you are reporting on.** The report header prints `解決対象ファイル`, and the oxlint side is collapsed onto that file. Spot-check a rule the oxlint rule set writes inside an `overrides[]` block (`src/rules/typescript.ts` puts its whole rule set there) and confirm the report shows the authored severity rather than the `categories` default. A whole scope showing up at `error` under ➕, or every option of a scope landing in 実質一致 / 判定不能, is the signature of a scoping miss — check `lib/fileScope.mjs` before reporting.
 
-4. **How to treat the option differences.** **Options cannot be judged from the snapshots.** ESLint's `calculateConfigForFile()` fills in schema defaults (for example `no-extra-boolean-cast` is only `['error']` in `rules/errors.js`, yet the snapshot shows `[{}]`), and oxlint drops rule options from `--print-config` when object-form `extends` is used ([oxc#22230](https://github.com/oxc-project/oxc/issues/22230); runtime behaviour is unaffected). For this section only, the script therefore imports `eslint.config.mjs` / `oxlint.config.ts` instead of reading the snapshots.
+4. **The plugin column under ❌ (unset on the oxlint side).** A row marked `未有効 (<scope>)` means the plugin is not enabled, so writing the rule alone would have no effect. Point out that the oxlint config's `plugins` may be incomplete.
+
+5. **How to treat the option differences.** **Options cannot be judged from the snapshots.** ESLint's `calculateConfigForFile()` fills in schema defaults (for example `no-extra-boolean-cast` is only `['error']` in `rules/errors.js`, yet the snapshot shows `[{}]`), and oxlint drops rule options from `--print-config` when object-form `extends` is used ([oxc#22230](https://github.com/oxc-project/oxc/issues/22230); runtime behaviour is unaffected). For this section only, the script therefore imports `eslint.config.mjs` / `oxlint.config.ts` instead of reading the snapshots.
 
    An option being absent on the oxlint side **does not mean it is unhandled**: when the eslint-config value equals oxlint's default, the oxlint side omits it on purpose. The script consults `node_modules/oxlint/configuration_schema.json` (which carries a `default` per option), resolves oxlint's effective value as "the value the rule set writes, otherwise the schema default", and splits the differences three ways:
 
@@ -111,7 +113,7 @@ Tell the user where the report was saved.
 | ⚠️ severity mismatch                   | Enabled on both sides but `warn` / `error` disagree. Decide which is correct and align them                                                 |
 | ➕ off in ESLint but enabled in oxlint | oxlint enables something ESLint deliberately disables. **Likely to produce reports the ESLint setup never had**                             |
 | ➕ enabled only in oxlint              | No corresponding ESLint rule. Either an oxlint-specific rule such as `oxc/*`, or a side effect of enabling whole `categories`               |
-| option differences                     | Severities agree but the written options differ. Read from the configuration sources, and **absent does not mean unhandled** (see step 3-4) |
+| option differences                     | Severities agree but the written options differ. Read from the configuration sources, and **absent does not mean unhandled** (see step 3-5) |
 | off on both sides                      | Disabled on both sides. Counts only                                                                                                         |
 
 `oxlint --rules -f json` (the binary lives at `packages/oxlint-config/node_modules/.bin/oxlint`) is the source of truth for whether oxlint supports a rule. The catalog follows the installed oxlint version, so **updating oxlint can change the verdict**.
@@ -123,7 +125,8 @@ Tell the user where the report was saved.
 | File                      | Responsibility                                                                    |
 | ------------------------- | --------------------------------------------------------------------------------- |
 | `lib/granularities.mjs`   | The granularity-to-directory table (`GRANULARITIES`)                              |
-| `lib/snapshot.mjs`        | Line oriented parser that reads `rules` / `plugins` out of a Vitest snapshot      |
+| `lib/snapshot.mjs`        | Line oriented parser that reads `rules` / `plugins` / `overrides` out of a Vitest snapshot |
+| `lib/fileScope.mjs`       | The target file, glob matching, and merging oxlint's matching `overrides`         |
 | `lib/catalog.mjs`         | The rule catalog from `oxlint --rules -f json`                                    |
 | `lib/optionSchema.mjs`    | Option defaults from `configuration_schema.json` and the three-way option verdict |
 | `lib/authoredOptions.mjs` | Collects the options as written in the configuration sources                      |
@@ -137,5 +140,6 @@ Tell the user where the report was saved.
 - Vitest snapshots cannot be `JSON.parse`d, because `pretty-format` leaves quotes inside strings unescaped (for example `"input[type="image"]"`). The parser relies on `pretty-format`'s deterministic layout — two space indentation, trailing commas — and never uses `eval`
 - `SCOPE_MAP` is the single source of truth for name conversion. Candidates are generated in priority order and resolved as **present in the resolved oxlint config → present in the catalog → the first candidate**, which absorbs scope drift such as `react-hooks/*` → `react/*` and `jest/*` ↔ `vitest/*`
 - Severities are normalised to `off` / `warn` / `error` from ESLint's `0` / `1` / `2` and oxlint's `allow` / `warn` / `deny`
-- Whether a rule is enabled, and at which severity, comes from the snapshots (file scoping is already resolved there, so they are accurate). **Options alone cannot be judged from the snapshots**, so `eslint.config.mjs` / `oxlint.config.ts` are imported and their `extends` chains walked, merging later definitions over earlier ones, to compare the options as written. Object key order is ignored (`stableStringify`)
+- **Both sides are resolved for one file — the `const filePath = '...'` in the ESLint side's `snapshot.test.mts`.** ESLint's snapshot is already flattened for that file by `calculateConfigForFile()`, but oxlint's `--print-config` is not: it emits the root `rules` (the raw `categories` expansion) next to an `overrides[]` array. `lib/fileScope.mjs` matches those `overrides` against the target file and merges them in declaration order. This cannot be skipped — `src/rules/*.ts` author entire rule sets inside `overrides[]`, so reading only the root `rules` reports every rule at its category severity and every option as unwritten
+- Whether a rule is enabled, and at which severity, comes from the snapshots, **after the `overrides` merge above**. **Options alone cannot be judged from the snapshots**, so `eslint.config.mjs` / `oxlint.config.ts` are imported and their `extends` chains walked (following `overrides` that match the target file), merging later definitions over earlier ones, to compare the options as written. Object key order is ignored (`stableStringify`)
 - The option verdict uses `node_modules/oxlint/configuration_schema.json`: `definitions.OxlintRules` → `DummyRuleMap.properties[<rule>]` holds each rule's option definition as a positional tuple, and each property's `default` is oxlint's default value

--- a/.claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs
@@ -13,6 +13,10 @@
  * sides' configuration sources rather than the snapshots (see
  * `lib/authoredOptions.mjs`).
  *
+ * Both sides are resolved for the single file the ESLint snapshot test targets:
+ * ESLint's snapshot is already flattened for it, while oxlint's `overrides[]`
+ * have to be matched and merged here (see `lib/fileScope.mjs`).
+ *
  * Usage:
  *   node .claude/skills/compare-lint-rules/scripts/compare-lint-rules.mjs <granularity> [options]
  *
@@ -30,6 +34,7 @@ import path from 'node:path';
 import { loadAuthoredOptions } from './lib/authoredOptions.mjs';
 import { loadCatalog } from './lib/catalog.mjs';
 import { compare } from './lib/compare.mjs';
+import { readTargetFile, resolveForFile } from './lib/fileScope.mjs';
 import { granularityNames, resolveGranularity } from './lib/granularities.mjs';
 import { collectWarnings, readComposition } from './lib/metadata.mjs';
 import { loadOptionSchema } from './lib/optionSchema.mjs';
@@ -74,15 +79,32 @@ async function main() {
 
   requireSnapshots(granularity, repoRoot, [eslintSnapshot, oxlintSnapshot]);
 
+  // The ESLint snapshot is resolved for exactly one file, so the oxlint side has
+  // to be collapsed onto that same file before the two are comparable.
+  const targetFile = readTargetFile(eslintDirAbs);
+
   const eslintRules = readSections(eslintSnapshot, 'ESLint', ['rules']).rules;
-  const { plugins, rules: oxlintRules } = readSections(
-    oxlintSnapshot,
-    'oxlint',
-    ['rules', 'plugins'],
+  const {
+    overrides,
+    plugins,
+    rules: oxlintRootRules,
+  } = readSections(oxlintSnapshot, 'oxlint', ['rules', 'plugins', 'overrides']);
+  const resolved = resolveForFile(oxlintRootRules, overrides, targetFile);
+  const oxlintRules = resolved.rules;
+  const oxlintPlugins = new Set([
+    ...(Array.isArray(plugins) ? plugins : []),
+    ...resolved.plugins,
+  ]);
+  const authoredEslint = await loadAuthoredOptions(
+    'eslint',
+    eslintDirAbs,
+    targetFile,
   );
-  const oxlintPlugins = new Set(Array.isArray(plugins) ? plugins : []);
-  const authoredEslint = await loadAuthoredOptions('eslint', eslintDirAbs);
-  const authoredOxlint = await loadAuthoredOptions('oxlint', oxlintDirAbs);
+  const authoredOxlint = await loadAuthoredOptions(
+    'oxlint',
+    oxlintDirAbs,
+    targetFile,
+  );
 
   const result = compare({
     authored: {
@@ -114,6 +136,7 @@ async function main() {
     oxlintPlugins: [...oxlintPlugins],
     oxlintRuleCount: Object.keys(oxlintRules).length,
     oxlintSnapshot: path.relative(repoRoot, oxlintSnapshot),
+    targetFile,
     warnings: collectWarnings({
       eslintDirAbs,
       eslintSnapshot,

--- a/.claude/skills/compare-lint-rules/scripts/lib/authoredOptions.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/authoredOptions.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { matchesGlob } from './fileScope.mjs';
+
 /**
  * @typedef {{error: string | null, options: Map<string, unknown[]> | null}} AuthoredOptions
  */
@@ -26,10 +28,14 @@ import { pathToFileURL } from 'node:url';
  *
  * @param {string} dir Absolute path to the side's config directory.
  *
+ * @param {string} targetFile The file the ESLint snapshot resolves its config
+ * for. oxlint's `overrides` are file scoped, so only the ones matching this path
+ * are collected.
+ *
  * @returns {Promise<AuthoredOptions>} The authored options keyed by rule name,
  * or an error message when the source could not be loaded.
  */
-export async function loadAuthoredOptions(side, dir) {
+export async function loadAuthoredOptions(side, dir, targetFile) {
   const entry = path.join(
     dir,
     side === 'eslint' ? 'eslint.config.mjs' : 'oxlint.config.ts',
@@ -46,7 +52,7 @@ export async function loadAuthoredOptions(side, dir) {
     const loaded = await import(pathToFileURL(entry).href);
     const options = new Map();
 
-    collectAuthoredRules(loaded.default, options);
+    collectAuthoredRules(loaded.default, options, targetFile);
 
     return { error: null, options };
   } catch (error) {
@@ -61,32 +67,46 @@ export async function loadAuthoredOptions(side, dir) {
  * Walks a flat ESLint config array or an oxlint config object, merging every
  * `rules` map in resolution order so that later definitions win.
  *
- * oxlint's `overrides` are deliberately skipped: they are file scoped and are not
- * part of the baseline the comparison is about.
+ * oxlint's `overrides` are followed when their `files` patterns match
+ * `targetFile`. They cannot be skipped: `src/rules/*.ts` author entire rule sets
+ * inside `overrides[]`, so ignoring them reports every option as unwritten and
+ * silently compares against oxlint's schema defaults instead.
  *
  * @param {any} config A config array, config object, or `extends` entry.
  *
  * @param {Map<string, unknown[]>} into Accumulator keyed by rule name.
  *
+ * @param {string} targetFile The file the comparison is resolved for.
+ *
  * @returns {void}
  */
-function collectAuthoredRules(config, into) {
+function collectAuthoredRules(config, into, targetFile) {
   if (!config || typeof config !== 'object') {
     return;
   }
 
   if (Array.isArray(config)) {
     for (const entry of config) {
-      collectAuthoredRules(entry, into);
+      collectAuthoredRules(entry, into, targetFile);
     }
 
     return;
   }
 
   // oxlint resolves `extends` before the config's own rules.
-  collectAuthoredRules(config.extends, into);
+  collectAuthoredRules(config.extends, into, targetFile);
 
   for (const [rule, value] of Object.entries(config.rules ?? {})) {
     into.set(rule, Array.isArray(value) ? value.slice(1) : []);
+  }
+
+  for (const override of config.overrides ?? []) {
+    const applies = (override?.files ?? []).some((pattern) =>
+      matchesGlob(pattern, targetFile),
+    );
+
+    if (applies) {
+      collectAuthoredRules({ rules: override.rules }, into, targetFile);
+    }
   }
 }

--- a/.claude/skills/compare-lint-rules/scripts/lib/fileScope.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/fileScope.mjs
@@ -1,0 +1,167 @@
+// @ts-check
+
+/**
+ * Resolves the file scoping that both sides express differently.
+ *
+ * The ESLint snapshot is already resolved for one concrete file, because
+ * `calculateConfigForFile()` flattens every matching config object into a single
+ * `rules` map. oxlint's `--print-config` does not: it emits the root `rules`
+ * alongside an `overrides[]` array, and leaves the matching to the linter. A
+ * comparison that reads only the root `rules` therefore sees the raw
+ * `categories` expansion and misses every rule the rule sets actually author,
+ * because `src/rules/*.ts` put their rules inside `overrides[]`.
+ *
+ * Everything here exists to line the oxlint side up with the single file the
+ * ESLint snapshot was resolved for.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ComparisonError } from './util.mjs';
+
+/**
+ * Reads the file path a granularity's ESLint snapshot test resolves its config
+ * for. That path is the basis for the whole comparison, so it is read from the
+ * test source rather than duplicated in a table that could drift.
+ *
+ * @param {string} eslintDirAbs Absolute path to the ESLint side directory.
+ *
+ * @returns {string} The target file path, normalised without a leading `./`.
+ *
+ * @throws {ComparisonError} When the test file or the path cannot be read.
+ */
+export function readTargetFile(eslintDirAbs) {
+  const file = path.join(eslintDirAbs, 'snapshot.test.mts');
+
+  if (!fs.existsSync(file)) {
+    throw new ComparisonError(
+      `ESLint 側の snapshot テストが見つかりません: ${file}`,
+    );
+  }
+
+  const match = /\bfilePath\s*=\s*['"`]([^'"`]+)['"`]/.exec(
+    fs.readFileSync(file, 'utf8'),
+  );
+
+  if (!match) {
+    throw new ComparisonError(
+      [
+        `${file} から対象ファイルパス（\`const filePath = '...'\`）を読み取れませんでした。`,
+        'oxlint 側の overrides をどのファイルに対して解決すべきか決まらないため、比較を続行できません。',
+      ].join('\n'),
+    );
+  }
+
+  return match[1].replace(/^\.\//, '');
+}
+
+/**
+ * Flattens oxlint's root `rules` with every `overrides[]` entry whose `files`
+ * patterns match the target file, in declaration order so that later entries
+ * win — the same precedence oxlint applies at runtime.
+ *
+ * @param {Record<string, unknown>} rootRules The snapshot's root `rules` map.
+ *
+ * @param {any[] | undefined} overrides The snapshot's `overrides` array.
+ *
+ * @param {string} targetFile The file the ESLint side resolved its config for.
+ *
+ * @returns {{plugins: string[], rules: Record<string, unknown>}} The rules in
+ * effect for `targetFile`, plus the plugins the matching overrides enable.
+ */
+export function resolveForFile(rootRules, overrides, targetFile) {
+  const rules = { ...rootRules };
+  const plugins = [];
+
+  for (const override of matchingOverrides(overrides, targetFile)) {
+    Object.assign(rules, override.rules ?? {});
+    plugins.push(...(override.plugins ?? []));
+  }
+
+  return { plugins, rules };
+}
+
+/**
+ * @param {any[] | undefined} overrides The snapshot's `overrides` array.
+ *
+ * @param {string} targetFile The file the ESLint side resolved its config for.
+ *
+ * @returns {any[]} The overrides that apply to `targetFile`, in order.
+ */
+export function matchingOverrides(overrides, targetFile) {
+  return (Array.isArray(overrides) ? overrides : []).filter((override) =>
+    (override?.files ?? []).some((pattern) => matchesGlob(pattern, targetFile)),
+  );
+}
+
+/**
+ * Matches a path against one of the glob patterns oxlint accepts in `files`.
+ *
+ * Only the subset the rule sets use is supported: `**`, `*`, `?`, and brace
+ * alternatives such as `{ts,tsx,cts,mts}`. A leading `**​/` matches zero or more
+ * directories, so `**​/*.ts` matches both `dummy.ts` and `apps/dummy.ts`.
+ *
+ * @param {string} pattern A glob pattern.
+ *
+ * @param {string} filePath A path, normalised without a leading `./`.
+ *
+ * @returns {boolean} `true` when the pattern matches.
+ */
+export function matchesGlob(pattern, filePath) {
+  let source = '';
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+
+    if (char === '*') {
+      if (pattern[index + 1] === '*') {
+        // `**/` may consume nothing at all, so that a root level file still
+        // matches. A bare `**` crosses directory separators.
+        if (pattern[index + 2] === '/') {
+          source += '(?:[^/]*/)*';
+          index += 2;
+        } else {
+          source += '.*';
+          index += 1;
+        }
+      } else {
+        source += '[^/]*';
+      }
+
+      continue;
+    }
+
+    if (char === '?') {
+      source += '[^/]';
+      continue;
+    }
+
+    if (char === '{') {
+      const end = pattern.indexOf('}', index);
+
+      if (end > index) {
+        source += `(?:${pattern
+          .slice(index + 1, end)
+          .split(',')
+          .map(escapeRegExp)
+          .join('|')})`;
+        index = end;
+        continue;
+      }
+    }
+
+    source += escapeRegExp(char);
+  }
+
+  return new RegExp(`^${source}$`).test(filePath);
+}
+
+/**
+ * @param {string} value A literal to embed in a regular expression.
+ *
+ * @returns {string} The escaped literal.
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/.claude/skills/compare-lint-rules/scripts/lib/report.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/report.mjs
@@ -35,6 +35,7 @@ function targetSection(meta) {
   const lines = [
     '## 対象',
     '',
+    `- 解決対象ファイル: \`${meta.targetFile}\`（両側ともこのファイルに対する実効設定で比較。oxlint 側は一致する \`overrides\` をマージ済み）`,
     `- ESLint snapshot: \`${meta.eslintSnapshot}\`（${meta.eslintRuleCount} ルール）`,
     `- oxlint snapshot: \`${meta.oxlintSnapshot}\`（${meta.oxlintRuleCount} ルール）`,
     `- ESLint 側構成: \`${meta.eslintComposition}\``,


### PR DESCRIPTION
## What changed / motivation ?

The `compare-lint-rules` skill read only the root `rules` map from oxlint's `--print-config` output and deliberately skipped `overrides[]`, assuming file scoped entries were not part of the baseline. That assumption does not hold — `packages/oxlint-config/src/rules/*.ts` author whole rule sets inside `overrides[]`, so the comparison saw the raw `categories` expansion rather than what the rule sets actually configure.

Both sides are now resolved for a single file. ESLint's snapshot is already flattened for one path by `calculateConfigForFile()`, so that path — the `const filePath = '...'` in the ESLint side's `snapshot.test.mts` — is read as the basis, and oxlint's matching `overrides` are merged in declaration order.

## Linked PR / Issues

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

### Impact on the reported results

Running the `typescript` granularity before and after:

| Category | Before | After |
| --- | --- | --- |
| Mapped | 328 | 327 |
| Unset on the oxlint side | 2 | 4 |
| Not supported by oxlint | 20 | 20 |
| Severity mismatch | 6 | 5 |
| Enabled only in oxlint | 86 | 78 |
| Off in ESLint but enabled in oxlint | 21 | 18 |
| Option differences needing work | 10 | 3 |

Seven of the ten reported option mismatches were false positives. `typescript/consistent-type-imports`, for instance, was flagged as unset even though `fixStyle: 'inline-type-imports'` is written in `src/rules/typescript.ts`.

### Changes

- `scripts/lib/fileScope.mjs` (new) — reads the target file from the ESLint snapshot test, matches globs, and merges oxlint's matching `overrides`. Reading the path from the test source rather than adding a column to `GRANULARITIES` keeps a single source of truth and follows the test if it changes
- `scripts/compare-lint-rules.mjs` — reads `overrides` from the snapshot, resolves them for the target file, and merges the plugins those overrides enable
- `scripts/lib/authoredOptions.mjs` — `collectAuthoredRules` now follows `overrides` matching the target file
- `scripts/lib/report.mjs` — the report header states which file the comparison was resolved for
- `SKILL.md` — adds a verification step for the `overrides` merge, and changes the snapshot freshness guidance so the tests are run to confirm the warning rather than reported as-is (the check only compares mtimes and false positives are common)

The glob matcher is hand written rather than a dependency, because the skill scripts have no `node_modules` of their own and the patterns in use are limited to `**`, `*`, `?`, and brace alternatives.

### Verification

- `essentials` is unaffected — identical counts before and after, confirmed by running the pre-fix script from `git archive HEAD`. No override matches its target `apps/dummy.js`
- `typescript` now agrees with a hand computed comparison
- The glob matcher passes 14 cases, including negatives such as `**/*.{jsx,tsx}` not matching `apps/dummy.ts` and `**/bin/*` not matching `a/bin/c/x.js`
