### PR TITLE
feat(oxlint-config): add the configs entry point

### DIFF
--- a/packages/oxlint-config/src/configs/index.ts
+++ b/packages/oxlint-config/src/configs/index.ts
@@ -1,0 +1,16 @@
+import testEssentials from './test/essentials/index.ts';
+import testReact from './test/react/index.ts';
+
+const test = {
+  essentials: testEssentials,
+  react: testReact,
+} as const;
+
+export { default as essentials } from './essentials/index.ts';
+export { default as jsdoc } from './jsdoc/index.ts';
+export { default as nextjs } from './nextjs/index.ts';
+export { default as node } from './node/index.ts';
+export { default as react } from './react/index.ts';
+export { default as storybook } from './storybook/index.ts';
+export { default as typescript } from './typescript/index.ts';
+export { test };


### PR DESCRIPTION
## What changed / motivation ?

Adds `src/configs/index.ts`, the entry point of `oxlint-config-moneyforward`.
`package.json` already declared `exports["."]` as `./dist/configs/index.js`, but no source file backed it, so the package could not be consumed even though every rule set had been mapped to `eslint-config-moneyforward`.

Each granularity is re-exported as a named export (`essentials`, `typescript`, `jsdoc`, `nextjs`, `node`, `react`, `storybook`). `test.essentials` and `test.react` are grouped under a single `test` object rather than flattened to `testEssentials` / `testReact`, so the access shape matches how the granularities are named in `eslint-config-moneyforward`.

No existing behaviour changes — this only adds exports.

## Linked PR / Issues

Completes the rule set mapping series: #496, #498, #500, #502, #503, #504, #505, #506

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- `pnpm build:js` (`tsc -p tsconfig.build.json`) passes with the new entry point.