### PR TITLE
feat(compare-lint-rules): add jsdoc and dedupe the granularity lists

### DIFF
--- a/.claude/commands/compare-lint-rules.md
+++ b/.claude/commands/compare-lint-rules.md
@@ -1,10 +1,10 @@
 ---
 description: Compare the eslint-config and oxlint-config snapshot test results, then list the rule mapping status, the differences, and what oxlint does not support
-argument-hint: <granularity> (essentials | typescript | nextjs | node | react | storybook | test.essentials | test.react)
+argument-hint: <granularity> (essentials | typescript | jsdoc | nextjs | node | react | storybook | test.essentials | test.react)
 ---
 
 Use the `compare-lint-rules` skill to compare how far the rule sets of `eslint-config-moneyforward` and `oxlint-config-moneyforward` map to each other.
 
 Granularity to compare: $ARGUMENTS
 
-When no granularity is given, offer `essentials` / `typescript` / `nextjs` / `node` / `react` / `storybook` / `test.essentials` / `test.react` and ask which one to compare. Do not batch several of them on your own.
+When no granularity is given, offer the granularities listed in the skill's table and ask which one to compare. Do not batch several of them on your own.

--- a/.claude/skills/compare-lint-rules/SKILL.md
+++ b/.claude/skills/compare-lint-rules/SKILL.md
@@ -123,19 +123,19 @@ Tell the user where the report was saved.
 
 `scripts/compare-lint-rules.mjs` only holds the CLI — argument parsing, I/O, and exiting on error. The judgement lives in `scripts/lib/`.
 
-| File                      | Responsibility                                                                    |
-| ------------------------- | --------------------------------------------------------------------------------- |
-| `lib/granularities.mjs`   | The granularity-to-directory table (`GRANULARITIES`)                              |
+| File                      | Responsibility                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| `lib/granularities.mjs`   | The granularity-to-directory table (`GRANULARITIES`)                                       |
 | `lib/snapshot.mjs`        | Line oriented parser that reads `rules` / `plugins` / `overrides` out of a Vitest snapshot |
-| `lib/fileScope.mjs`       | The target file, glob matching, and merging oxlint's matching `overrides`         |
-| `lib/catalog.mjs`         | The rule catalog from `oxlint --rules -f json`                                    |
-| `lib/optionSchema.mjs`    | Option defaults from `configuration_schema.json` and the three-way option verdict |
-| `lib/authoredOptions.mjs` | Collects the options as written in the configuration sources                      |
-| `lib/ruleName.mjs`        | ESLint name to oxlint name conversion (`SCOPE_MAP`, `ruleNameAliases`)            |
-| `lib/compare.mjs`         | Rule classification                                                               |
-| `lib/report.mjs`          | Markdown output                                                                   |
-| `lib/metadata.mjs`        | Snapshot freshness warnings and rule set composition                              |
-| `lib/util.mjs`            | `ComparisonError`, `stableStringify`, and friends                                 |
+| `lib/fileScope.mjs`       | The target file, glob matching, and merging oxlint's matching `overrides`                  |
+| `lib/catalog.mjs`         | The rule catalog from `oxlint --rules -f json`                                             |
+| `lib/optionSchema.mjs`    | Option defaults from `configuration_schema.json` and the three-way option verdict          |
+| `lib/authoredOptions.mjs` | Collects the options as written in the configuration sources                               |
+| `lib/ruleName.mjs`        | ESLint name to oxlint name conversion (`SCOPE_MAP`, `ruleNameAliases`)                     |
+| `lib/compare.mjs`         | Rule classification                                                                        |
+| `lib/report.mjs`          | Markdown output                                                                            |
+| `lib/metadata.mjs`        | Snapshot freshness warnings and rule set composition                                       |
+| `lib/util.mjs`            | `ComparisonError`, `stableStringify`, and friends                                          |
 
 - Expected failures (missing snapshot, missing oxlint binary, unparsable file) throw `ComparisonError`, which the CLI turns into a message on stderr and exit code 2. Nothing under `lib/` calls `process.exit`
 - Vitest snapshots cannot be `JSON.parse`d, because `pretty-format` leaves quotes inside strings unescaped (for example `"input[type="image"]"`). The parser relies on `pretty-format`'s deterministic layout — two space indentation, trailing commas — and never uses `eval`

--- a/.claude/skills/compare-lint-rules/SKILL.md
+++ b/.claude/skills/compare-lint-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compare-lint-rules
-description: Compares the snapshot test results of eslint-config-moneyforward and oxlint-config-moneyforward to judge, one granularity at a time, whether the oxlint rule sets map to the ESLint ones. Lists the differences (unset on the oxlint side, severity mismatches, enabled only on the oxlint side) and the rules oxlint does not support. Use when comparing essentials / typescript / nextjs / node / react / storybook / test.essentials / test.react, or when asked whether the rules are mapped or which rules oxlint cannot cover.
+description: Compares the snapshot test results of eslint-config-moneyforward and oxlint-config-moneyforward to judge, one granularity at a time, whether the oxlint rule sets map to the ESLint ones. Lists the differences (unset on the oxlint side, severity mismatches, enabled only on the oxlint side) and the rules oxlint does not support. Use when comparing essentials / typescript / jsdoc / nextjs / node / react / storybook / test.essentials / test.react, or when asked whether the rules are mapped or which rules oxlint cannot cover.
 ---
 
 # eslint-config / oxlint-config rule mapping comparison
@@ -24,6 +24,7 @@ The script warns when a snapshot is older than the configuration it captures. Th
 | ----------------------- | --------------------------------------------- | ----------------------------------------------- |
 | `essentials`            | `packages/eslint-config/test/flat/essentials` | `packages/oxlint-config/src/configs/essentials` |
 | `typescript`            | `.../test/flat/typescript`                    | `.../src/configs/typescript`                    |
+| `jsdoc`                 | `.../test/flat/jsdoc`                         | `.../src/configs/jsdoc`                         |
 | `nextjs` (alias `next`) | `.../test/flat/next`                          | `.../src/configs/nextjs`                        |
 | `node`                  | `.../test/flat/node`                          | `.../src/configs/node`                          |
 | `react`                 | `.../test/flat/react`                         | `.../src/configs/react`                         |

--- a/.claude/skills/compare-lint-rules/scripts/lib/granularities.mjs
+++ b/.claude/skills/compare-lint-rules/scripts/lib/granularities.mjs
@@ -20,6 +20,10 @@ export const GRANULARITIES = {
     eslintDir: 'packages/eslint-config/test/flat/typescript',
     oxlintDir: 'packages/oxlint-config/src/configs/typescript',
   },
+  jsdoc: {
+    eslintDir: 'packages/eslint-config/test/flat/jsdoc',
+    oxlintDir: 'packages/oxlint-config/src/configs/jsdoc',
+  },
   nextjs: {
     eslintDir: 'packages/eslint-config/test/flat/next',
     oxlintDir: 'packages/oxlint-config/src/configs/nextjs',


### PR DESCRIPTION
## What changed / motivation ?

The jsdoc rule set gained snapshot tests on both sides in e13d81f, but the `compare-lint-rules` skill was never told about them, so it still rejected `jsdoc` as an unknown granularity. This PR makes the jsdoc rule set comparable like every other granularity, and reduces the number of places that have to be edited the next time a granularity is added.

Three commits:

1. **`feat`** — adds the `jsdoc` entry to `GRANULARITIES` in `scripts/lib/granularities.mjs`, pointing at `packages/eslint-config/test/flat/jsdoc` and `packages/oxlint-config/src/configs/jsdoc`. No alias is added: the ESLint side directory is already named `jsdoc`, so the name needs no shortening.
2. **`docs`** — `GRANULARITIES` is the single source of truth at runtime, but the granularity list is also spelled out by hand in three static places that cannot be generated from it: the skill's frontmatter `description` (it drives skill selection), the skill's granularity table (it also carries the directory paths and aliases), and the command's `argument-hint` (it is shown in the completion UI). All three now list `jsdoc`. The command body carried a fourth copy, redundant with both its own `argument-hint` and the skill's table; it now refers to the skill's table instead, so the hand-maintained lists drop from four to three.
3. **`style`** — realigns the column widths of the skill's "How the script works" table, which did not match Prettier's output. That breakage predates this branch and is fixed here only because the branch already touches the file.

## Linked PR / Issues

Follow-up to #500.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- Both jsdoc snapshot directories were verified to exist on `main`.
- `packages/oxlint-config/README.md` also enumerates the rule sets, but that documents the package's own public entry points rather than the skill's granularities, and it already covers `jsdoc`. It is left untouched.
- Both edited Markdown files were verified against the repository's Prettier configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)