### PR TITLE
chore(ci): pass NPM_TOKEN to the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,4 @@ jobs:
         run: pnpm -r --workspace-concurrency=1 release ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changed / motivation ?

Pass `secrets.NPM_TOKEN` to the `Release` step of the release workflow so that `semantic-release` can authenticate against the npm registry.

This is needed to publish `oxlint-config-moneyforward` to npmjs. npmjs recommends OIDC (trusted publishing) as the default way to authenticate, but a package has to already exist on the registry before it can be registered as a trusted publisher. The very first release of `oxlint-config-moneyforward` therefore has to authenticate with an npm access token.

`id-token: write` is left as is, so provenance keeps working. Once the package is published and OIDC can take over, `NPM_TOKEN` can be dropped from this workflow.

## Linked PR / Issues

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- npm Trusted publishing: <https://docs.npmjs.com/trusted-publishers>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
