### PR TITLE
ci: keep the release pull request when a package fails to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,21 +48,25 @@ jobs:
       - name: Initialize
         uses: ./.github/actions/restore-node
 
+      # `--no-bail` keeps the packages independent: one failing release must not stop the others.
       - name: Release
-        run: pnpm -r --workspace-concurrency=1 release ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+        run: pnpm -r --workspace-concurrency=1 --no-bail release ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Resolve branch name
-        if: ${{ github.event.inputs.dry_run != 'true' }}
+        if: ${{ !cancelled() && github.event.inputs.dry_run != 'true' }}
         id: branch
         run: echo "name=chore/$(date -u +%Y%m%d)-release-packages" >> "$GITHUB_OUTPUT"
 
       # The default branch rejects direct pushes, so the version bumps and changelogs
       # generated above are handed back to `main` through a pull request.
+      #
+      # This runs even when the release step failed: a package that did publish has already
+      # been tagged, so dropping its version bump would leave the repository out of sync.
       - name: Create release pull request
-        if: ${{ github.event.inputs.dry_run != 'true' }}
+        if: ${{ !cancelled() && github.event.inputs.dry_run != 'true' }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [eslint-config-moneyforward-v6.0.1](https://github.com/moneyforward/frontend-tools/compare/6.0.0...6.0.1) (2026-08-21)
+
 ## [eslint-config-moneyforward-v6.0.0](https://github.com/moneyforward/frontend-tools/compare/5.1.4...6.0.0) (2026-04-18)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-moneyforward",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Money Forward's ESLint rules as an extensible shared config.",
   "exports": {
     "./flat": {


### PR DESCRIPTION
## What changed / motivation ?

Release run [32441476178](https://github.com/moneyforward/frontend-tools/actions/runs/32441476178) published `eslint-config-moneyforward@6.0.1` and then failed on `oxlint-config-moneyforward`, because npm trusted publishing cannot bootstrap a package that does not exist yet:

```
[@semantic-release/npm] › ℹ  OIDC token exchange with the npm registry failed:
                             404 OIDC token exchange error - package not found
npm error code EOTP
npm error This operation requires a one-time password.
```

That exposed two problems in the workflow added by #511:

1. `Create release pull request` inherits an implicit `success()` in its `if` condition, so it was skipped. `eslint-config` was already published and tagged, but its version bump and changelog entry were discarded with the runner. This pull request guards the step with `!cancelled()` instead.
2. `pnpm -r` bails on the first failure, so a single package can block every package queued behind it. `--no-bail` keeps them independent; the step still exits non-zero when any of them fails.

It also restores what run 32441476178 lost: `packages/eslint-config` is bumped to `6.0.1` and the changelog gets its `6.0.1` entry.

## Linked PR / Issues

- Follows up #511
- Failed run: https://github.com/moneyforward/frontend-tools/actions/runs/32441476178

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- https://docs.npmjs.com/about-access-tokens
- https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions

## Notes

- The restored `6.0.1` changelog entry is heading-only, matching the [6.0.1 release notes](https://github.com/moneyforward/frontend-tools/releases/tag/6.0.1). The generated notes came out empty even though 20+ `fix` commits triggered the patch release, which `6.0.0` and `5.1.4` did not. That is a separate defect, tracked outside this pull request.
- The orphan tag `oxlint-config-moneyforward-v1.0.0` (pushed before the failed publish, with no npm package and no GitHub release behind it) has already been deleted from the remote.
- Publishing `oxlint-config-moneyforward` for the first time still needs an `NPM_TOKEN` that can publish without an OTP.
