### PR TITLE
fix(release-config): pin conventional-changelog-conventionalcommits to v9

### DIFF
--- a/packages/release-config/package.json
+++ b/packages/release-config/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@semantic-release/changelog": "7.0.0",
     "@semantic-release/npm": "13.1.5",
-    "conventional-changelog-conventionalcommits": "10.3.0",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "semantic-release-monorepo": "8.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: 13.1.5
         version: 13.1.5(semantic-release@25.0.9(supports-color@10.2.2)(typescript@5.9.3))
       conventional-changelog-conventionalcommits:
-        specifier: 10.3.0
-        version: 10.3.0
+        specifier: 9.3.1
+        version: 9.3.1
       semantic-release-monorepo:
         specifier: 8.0.2
         version: 8.0.2(semantic-release@25.0.9(supports-color@10.2.2)(typescript@5.9.3))(supports-color@10.2.2)
@@ -390,10 +390,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@conventional-changelog/template@1.3.0':
-    resolution: {integrity: sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==}
-    engines: {node: '>=22'}
 
   '@csstools/css-calc@3.3.0':
     resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
@@ -2160,9 +2156,9 @@ packages:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@10.3.0:
-    resolution: {integrity: sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==}
-    engines: {node: '>=22'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.0.0:
     resolution: {integrity: sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==}
@@ -5520,8 +5516,6 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@conventional-changelog/template@1.3.0': {}
-
   '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -7266,9 +7260,9 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@10.3.0:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
-      '@conventional-changelog/template': 1.3.0
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.0.0:
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
     {
       "groupName": "semantic-release family",
       "matchPackageNames": ["semantic-release", "@semantic-release/*"]
+    },
+    {
+      "description": "v10 returns its templates as functions under `writer.template`, but conventional-changelog-writer@8 - the version @semantic-release/release-notes-generator depends on - only reads Handlebars strings from `writer.mainTemplate`. The result is release notes containing nothing but the heading. Lift this once release-notes-generator ships a writer that understands v10.",
+      "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+      "allowedVersions": "<10"
     }
   ]
 }


### PR DESCRIPTION
## What changed / motivation ?

Release notes have been heading-only since #476 bumped `conventional-changelog-conventionalcommits` from `9.3.1` to `10.3.0` on 2026-08-12. Both releases published after that bump came out empty:

- [6.0.1](https://github.com/moneyforward/frontend-tools/releases/tag/6.0.1)
- [oxlint-config-moneyforward-v1.0.0](https://github.com/moneyforward/frontend-tools/releases/tag/oxlint-config-moneyforward-v1.0.0) — despite 15 `feat` commits and a breaking change

### Root cause

v10 moved its templates into `@conventional-changelog/template` and returns them as **functions** under `writer.template`:

```
v9.3.1  writer.mainTemplate -> string    writer.template -> undefined
v10.3.0 writer.mainTemplate -> undefined writer.template -> function
```

`conventional-changelog-writer@8`, which `@semantic-release/release-notes-generator@14.1.0` depends on, reads `options.mainTemplate` and expects Handlebars strings:

```js
// conventional-changelog-writer@8.0.0/dist/template.js
options.mainTemplate || readFile(join(dirname, '..', 'templates', 'template.hbs'), 'utf-8'),
...
Handlebars.registerPartial('commit', commitPartial);
```

So with v10 the main template silently falls back to the writer's own default, and `commitPartial` is registered as a function Handlebars cannot render with that signature. The heading survives; every commit section is dropped.

`release-notes-generator@14.1.0` still pins the preset to `9.1.0` in its own devDependencies, so v9 is the tested combination. This restores `9.3.1` — the exact version in place for the last release that produced correct notes (2026-04-18).

Not a `semantic-release-monorepo` filtering problem: the run log shows `Found 15 commits for package oxlint-config-moneyforward since last release` for the `generateNotes` step too.

### Verification

Replayed `generateNotes` over the same 15 oxlint-config commits outside CI:

| preset config | result |
| --- | --- |
| `preset: conventionalcommits` (v10 resolved) | heading only |
| `preset: conventionalcommits` + v9 `writerOpts` | full notes, Features + BREAKING CHANGES |
| default preset (angular) | full notes |

`renovate.json` gains an `allowedVersions: "<10"` rule so the next major does not silently reintroduce this.

## Linked PR / Issues

- Regressed by #476
- Affected releases: #513

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits

## Notes

This touches only `packages/release-config` (private) and root files, so it triggers no package release even though it is typed `fix`.

The notes already published for 6.0.1 and oxlint-config 1.0.0 are not backfilled here.
