### PR TITLE
ci: make each package check a distinct required status

### DIFF
--- a/.github/actions/check-package/action.yml
+++ b/.github/actions/check-package/action.yml
@@ -1,0 +1,43 @@
+name: Check package
+
+description: Run a pnpm task for one workspace package, skipping when that package is untouched
+
+inputs:
+  package:
+    description: Directory name under `packages/`
+    required: true
+  task:
+    description: pnpm script to run
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # The calling workflow deliberately carries no `paths` filter: these jobs are required status
+    # checks, and a filtered workflow that never runs leaves the check permanently "expected",
+    # which blocks the pull request forever. The filtering happens here instead, so the check run
+    # still reports success on an unrelated pull request — it just does no work.
+    - name: Detect changes
+      id: changes
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+             --paginate --jq '.[].filename' \
+           | grep -q "^packages/${{ inputs.package }}/"; then
+          echo 'matched=true' >> "$GITHUB_OUTPUT"
+        else
+          echo "::notice::No changes under packages/${{ inputs.package }}/, skipping ${{ inputs.task }}."
+          echo 'matched=false' >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Initialize
+      if: steps.changes.outputs.matched == 'true'
+      uses: ./.github/actions/restore-node
+
+    - name: Run ${{ inputs.task }}
+      if: steps.changes.outputs.matched == 'true'
+      shell: bash
+      working-directory: packages/${{ inputs.package }}
+      run: pnpm ${{ inputs.task }}

--- a/.github/workflows/check_eslint_config.yml
+++ b/.github/workflows/check_eslint_config.yml
@@ -1,20 +1,18 @@
 name: Check eslint-config
 
+# No `paths` filter: these jobs are required status checks, and a filtered workflow that never
+# runs leaves the check permanently "expected", which blocks the pull request forever.
+# `check-package` skips the work when the package is untouched.
 on:
   pull_request:
     branches:
       - "*"
-    paths:
-      - "packages/eslint-config/**"
 
 jobs:
-  check:
+  # The job id is the check-run name. It has to be unique across the three package workflows,
+  # otherwise a required `check (lint)` cannot tell one package from another.
+  eslint-config:
     runs-on: ubuntu-latest
-    env:
-      WORKING_DIRECTORY: packages/eslint-config
-    defaults:
-      run:
-        working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,10 +24,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Initialize
-        uses: ./.github/actions/restore-node
+      - uses: ./.github/actions/check-package
         with:
-          working_directory: ${{ env.WORKING_DIRECTORY }}
-
-      - name: Run ${{ matrix.task }}
-        run: pnpm ${{ matrix.task }}
+          package: eslint-config
+          task: ${{ matrix.task }}

--- a/.github/workflows/check_oxlint_config.yml
+++ b/.github/workflows/check_oxlint_config.yml
@@ -1,20 +1,18 @@
 name: Check oxlint-config
 
+# No `paths` filter: these jobs are required status checks, and a filtered workflow that never
+# runs leaves the check permanently "expected", which blocks the pull request forever.
+# `check-package` skips the work when the package is untouched.
 on:
   pull_request:
     branches:
       - "*"
-    paths:
-      - "packages/oxlint-config/**"
 
 jobs:
-  check:
+  # The job id is the check-run name. It has to be unique across the three package workflows,
+  # otherwise a required `check (lint)` cannot tell one package from another.
+  oxlint-config:
     runs-on: ubuntu-latest
-    env:
-      WORKING_DIRECTORY: packages/oxlint-config
-    defaults:
-      run:
-        working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,10 +25,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Initialize
-        uses: ./.github/actions/restore-node
+      - uses: ./.github/actions/check-package
         with:
-          working_directory: ${{ env.WORKING_DIRECTORY }}
-
-      - name: Run ${{ matrix.task }}
-        run: pnpm ${{ matrix.task }}
+          package: oxlint-config
+          task: ${{ matrix.task }}

--- a/.github/workflows/check_stylelint_config.yml
+++ b/.github/workflows/check_stylelint_config.yml
@@ -1,20 +1,18 @@
 name: Check stylelint-config
 
+# No `paths` filter: these jobs are required status checks, and a filtered workflow that never
+# runs leaves the check permanently "expected", which blocks the pull request forever.
+# `check-package` skips the work when the package is untouched.
 on:
   pull_request:
     branches:
       - "*"
-    paths:
-      - "packages/stylelint-config/**"
 
 jobs:
-  check:
+  # The job id is the check-run name. It has to be unique across the three package workflows,
+  # otherwise a required `check (lint)` cannot tell one package from another.
+  stylelint-config:
     runs-on: ubuntu-latest
-    env:
-      WORKING_DIRECTORY: packages/stylelint-config
-    defaults:
-      run:
-        working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,10 +24,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Initialize
-        uses: ./.github/actions/restore-node
+      - uses: ./.github/actions/check-package
         with:
-          working_directory: ${{ env.WORKING_DIRECTORY }}
-
-      - name: Run ${{ matrix.task }}
-        run: pnpm ${{ matrix.task }}
+          package: stylelint-config
+          task: ${{ matrix.task }}

--- a/.github/workflows/verify_bot_approval.yml
+++ b/.github/workflows/verify_bot_approval.yml
@@ -1,0 +1,70 @@
+name: Verify Bot Approval
+
+# Temporary harness.
+#
+# The release workflow approves its own pull request as `github-actions[bot]` and then relies on
+# auto-merge. Whether that approval satisfies the organization ruleset `org-ciso-approvers` cannot
+# be read from the API without `admin:org`, so it has to be observed once against a real pull
+# request. Dispatch this workflow with a pull request number and read the job summary:
+# `reviewDecision: APPROVED` together with `mergeStateStatus: CLEAN` means the approval counts.
+#
+# Delete this workflow once the answer is recorded.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request to approve
+        required: true
+        type: string
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR: ${{ inputs.pull_request_number }}
+    steps:
+      - name: Report the state before approving
+        run: |
+          {
+            echo "### Before"
+            echo
+            gh pr view "$PR" --json reviewDecision,mergeStateStatus,mergeable,isDraft,state \
+              --jq 'to_entries[] | "- **\(.key)**: `\(.value)`"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A pull request with auto-merge already enabled would merge the moment the approval lands,
+      # so refuse unless every check has settled successfully.
+      - name: Refuse to approve while a check is unsettled
+        run: |
+          unsettled=$(gh pr checks "$PR" --json name,state \
+            --jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED" and .state != "NEUTRAL")]
+                  | map("\(.name)=\(.state)") | join(", ")')
+          if [ -n "$unsettled" ]; then
+            echo "::error::Refusing to approve, these checks are not green: $unsettled"
+            exit 1
+          fi
+
+      - name: Approve
+        run: |
+          gh pr review "$PR" --approve \
+            --body "Approved by the \`Verify Bot Approval\` workflow to confirm that a \`github-actions[bot]\` review satisfies the branch rules."
+
+      - name: Report the state after approving
+        run: |
+          {
+            echo "### After"
+            echo
+            gh pr view "$PR" --json reviewDecision,mergeStateStatus,mergeable,state \
+              --jq 'to_entries[] | "- **\(.key)**: `\(.value)`"'
+            echo
+            echo "Reviews:"
+            echo
+            gh pr view "$PR" --json reviews \
+              --jq '.reviews[] | "- \(.author.login): \(.state)"'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed / motivation ?

Auto-merge only waits for **required** status checks. The only required context on `main` today is `check` from `check_pull_request_title.yml`, so extending the release workflow's auto approval to Renovate would merge dependency bumps whose tests fail — #482 is in exactly that state right now (`check (test)` FAILURE, but `mergeStateStatus: BLOCKED` only because a review is missing).

Promoting the package checks to required contexts needed two problems fixed first:

- **Colliding names.** All three package workflows declared their job as `check`, so their check runs were all named `check (lint)` / `check (test)` (`check (build)` for oxlint-config only). A required `check (lint)` could not tell one package from another. Each job id is now the package name, so the matrix produces `eslint-config (lint)`, `oxlint-config (build)`, and so on.
- **Path filters.** Each workflow was filtered on its own package path, so a pull request touching only `.github/` — such as #516 — reported none of them. A required context that is never reported stays "Expected — waiting for status" and blocks the pull request permanently. The filters are removed; the full matrix now runs on every pull request, roughly a minute of wall clock in parallel.

`verify_bot_approval.yml` is a **temporary harness**, not part of the release path. It answers the one question the API cannot without `admin:org`: whether a review submitted by `github-actions[bot]` satisfies the `org-ciso-approvers` ruleset, which is what the release workflow's auto-merge depends on. Dispatch it with a pull request number and read the job summary — `reviewDecision: APPROVED` plus `mergeStateStatus: CLEAN` means the approval counts. It refuses to approve unless every check is green, so it cannot merge a pull request that already has auto-merge enabled.

**After merging**, the required contexts on `main` still need updating:

```
check
eslint-config (lint)      eslint-config (test)
oxlint-config (lint)      oxlint-config (test)      oxlint-config (build)
stylelint-config (lint)   stylelint-config (test)
```

Note that #482 will stay blocked until Renovate rebases it onto this change, since its existing check runs still carry the old names.

## Linked PR / Issues

Follows up on #516. Unblocks extending that automation to Renovate pull requests.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- This pull request is itself the proof that the path filters had to go: it touches only `.github/`, and under the old configuration none of the package checks would have reported.
- [About protected branches — require status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)
